### PR TITLE
Remove non-docker-metadata generated tags in image release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,5 +70,5 @@ jobs:
           build-args: |
             BUILD_ENV=release
             PLASTERED_RELEASE_TAG=${{ github.ref_name }}
-          tags: ${{ env.IMAGE_REGISTRY }}/${{ steps.meta.outputs.tags }},${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          tags: ${{ env.IMAGE_REGISTRY }}/${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## What?
* Remove the non-docker-metadata step-generated Docker image tags from the image release step to resolve image uri's errors during publishing.
