### PR TITLE
Add CLI doc auto-generation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 # whitelisted folders / files for the main docker image
 !build_scripts
 !examples
+!docs
 !plastered
 !entrypoint.sh
 !requirements.txt 

--- a/Makefile
+++ b/Makefile
@@ -31,5 +31,9 @@ code-format-check: docker-build  ## Runs code-auto-formatting checks, lint check
 code-format: docker-build  ## Runs code-auto-formatting, followed by lint checks, and then security checks
 	docker run -it --rm -v $(PROJECT_DIR_PATH):/project_src_mnt --entrypoint /app/build_scripts/code-format.sh wv/plastered:latest
 
+# TODO: write a script that does the rendering of the CLI docs via the mkdocs CLI
+render-cli-doc: docker-build  ## Autogenerates the CLI help output as a markdown file
+	docker run -it --rm -v $(PROJECT_DIR_PATH):/project_src_mnt --entrypoint /app/build_scripts/render-cli-docs.sh wv/plastered:latest
+
 docker-test: docker-build  ## Runs unit tests inside a local docker container
 	docker run -it --rm -v $(PROJECT_DIR_PATH)/docs:/docs --entrypoint /app/tests/tests_entrypoint.sh wv/plastered:latest "$(TEST_TARGET)"

--- a/build_scripts/render-cli-docs.sh
+++ b/build_scripts/render-cli-docs.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+export PYTHONPATH="${APP_DIR}/"
+export TARGET_DOC_FILEPATH="${APP_DIR}/docs/CLI_reference.md"
+if [[ -z "${GITHUB_ACTIONS}" ]]; then
+    echo "Not running in a github actions environment. Will overrite auto-genned CLI doc with fresh contents."
+    export TARGET_DOC_FILEPATH=/project_src_mnt/docs/CLI_reference.md
+fi
+
+python "${APP_DIR}/build_scripts/render_cli_markdown.py"

--- a/build_scripts/render_cli_markdown.py
+++ b/build_scripts/render_cli_markdown.py
@@ -1,0 +1,61 @@
+import os
+from textwrap import dedent
+from typing import List, Optional
+
+from mkdocs_click._extension import replace_command_docs
+from mkdocs_click._processing import replace_blocks
+
+# NOTE: the mkdocs_click CLI works with generating full mkdocs HTML,
+# But we just want plain `.md` files output from that library, so this script
+# uses the mkdocs_click lib to handle the static markdown file generation only.
+# Heavily adopted from their unit test case here:
+# https://github.com/mkdocs/mkdocs-click/blob/c013cb0df7c95c1d8aa2e21c8932d7156e83eba9/tests/test_extension.py#L27-L41
+
+
+_TARGET_DOC_FILEPATH = os.getenv("TARGET_DOC_FILEPATH")
+
+
+def get_markdown_lines() -> List[str]:
+    mkdocks_click_md_text = dedent(
+        """
+        ::: mkdocs-click
+        :module: plastered.cli
+        :command: cli
+    """
+    ).rstrip()
+    mkdocs_options = {
+        "module": "plastered.cli",
+        "command": "cli",
+    }
+    # adopted from mkdocs_click internals here:
+    # https://github.com/mkdocs/mkdocs-click/blob/master/mkdocs_click/_extension.py#L55
+    raw_markdown_lines = list(
+        replace_blocks(
+            lines=mkdocks_click_md_text.split("\n"),
+            title="mkdocs-click",
+            replace=lambda **options: replace_command_docs(has_attr_list=False, **mkdocs_options),
+        )
+    )
+    processed_markdown_lines = [
+        "# `plastered` CLI Reference",
+        "",
+        "> NOTE: this doc is auto-generated from the CLI source code. For a more thorough version of this information, run `plastered --help`, as outlined in the user guide.",
+    ]
+    processed_markdown_lines.extend([line.replace("cli", "plastered") for line in raw_markdown_lines[3:-2]])
+    return processed_markdown_lines
+
+
+def main(is_github_action: Optional[bool] = False) -> None:
+    markdown_lines = get_markdown_lines()
+    print(f"writing to output filepath: {_TARGET_DOC_FILEPATH} ...")
+    if is_github_action:
+        pass
+    else:
+        with open(_TARGET_DOC_FILEPATH, "w") as f:
+            f.writelines("\n".join(markdown_lines))
+
+    print("\n".join(markdown_lines))
+
+
+if __name__ == "__main__":
+    main(is_github_action=os.getenv("GITHUB_ACTIONS"))

--- a/docs/CLI_reference.md
+++ b/docs/CLI_reference.md
@@ -1,0 +1,106 @@
+# `plastered` CLI Reference
+
+> NOTE: this doc is auto-generated from the CLI source code. For a more thorough version of this information, run `plastered --help`, as outlined in the user guide.
+plastered: Finds your LFM recs and snatches them from RED.
+
+**Usage:**
+
+```text
+plastered [OPTIONS] COMMAND [ARGS]...
+```
+
+**Options:**
+
+```text
+  --version                       Show the version and exit.
+  -v, --verbosity [DEBUG|INFO|WARNING|ERROR]
+                                  Sets the logging level.  [default: WARNING]
+  --red-user-id INTEGER
+  --red-api-key TEXT
+  --lfm-api-key TEXT
+  --lfm-username TEXT
+  --lfm-password TEXT
+  --help                          Show this message and exit.
+```
+
+## cache
+
+Helper command to inspect or empty the local run cache(s). See this docs page for more info on the run cache: https://github.com/windexvalence/plastered/blob/main/docs/configuration_reference.md
+
+**Usage:**
+
+```text
+plastered cache [OPTIONS] {api|scraper|@all}
+```
+
+**Options:**
+
+```text
+  -c, --config PATH  Absolute path to the application config.yaml file.  [env
+                     var: PLASTERED_CONFIG; required]
+  --info             Print meta-info about the disk cache(s).
+  --empty            When present, clear cache specified by the command
+                     argument.
+  --check            Verify / try to fix diskcache consistency for specified
+                     cache argument.
+  --help             Show this message and exit.
+```
+
+## conf
+
+Output the contents of your existing config.yaml, along with any default values and/or CLI option overrides.
+
+**Usage:**
+
+```text
+plastered conf [OPTIONS]
+```
+
+**Options:**
+
+```text
+  -c, --config PATH  Absolute path to the application config.yaml file.  [env
+                     var: PLASTERED_CONFIG; required]
+  --help             Show this message and exit.
+```
+
+## init-conf
+
+Output the contents of a template starter config to aid in initial app setup. Output may be redirected to the desired config filepath on your host machine.
+
+**Usage:**
+
+```text
+plastered init-conf [OPTIONS]
+```
+
+**Options:**
+
+```text
+  --help  Show this message and exit.
+```
+
+## scrape
+
+Run the app to pull LFM recs and snatch them from RED, per the settings of your config.yaml along with any CLI overrides you provide.
+
+**Usage:**
+
+```text
+plastered scrape [OPTIONS]
+```
+
+**Options:**
+
+```text
+  -c, --config PATH               Absolute path to the application config.yaml
+                                  file.  [env var: PLASTERED_CONFIG; required]
+  --no-snatch                     When present, disables downloading the
+                                  .torrent files matched to your LFM recs
+                                  results.
+  -r, --rec-types [album|track|@all]
+                                  Indicate what type of LFM recs to scrape and
+                                  snatch. Defaults to 'rec_types_to_scrape'
+                                  config setting otherwise.
+  --help                          Show this message and exit.
+```

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -49,6 +49,8 @@ plastered scrape
 
 ### Additional Commands
 
+For the exhaustive list of `plastered` CLI commands and options, refer to the [Plastered CLI Reference](./CLI_reference.md)
+
 Along with `scrape`, plastered offers a few other helpful commands. You can find the full list of commands by running `plastered --help`.
 
 Further command-specific details are accessible by running the command of interest with the help flag, for example to see more details about the `plastered cache` command, run the following:

--- a/tests/deploy_tests/test_cli_autodocs_fresh.py
+++ b/tests/deploy_tests/test_cli_autodocs_fresh.py
@@ -1,0 +1,34 @@
+"""
+This file contains unit tests to ensure that the auto-generated markdown docs from the CLI help commands
+are properly in sync with the current CLI code. If not in sync, will error and indicates that the 
+`make render-cli-doc` command should be run and the changes committed.
+"""
+
+import os
+
+import pytest
+
+from tests.conftest import PROJECT_ABS_PATH
+
+_CLI_DOC_FILEPATH = os.path.join(PROJECT_ABS_PATH, "docs/CLI_reference.md")
+_RENDER_DOC_SCRIPT_FILEPATH = os.path.join(PROJECT_ABS_PATH, "build_scripts", "render_cli_markdown.py")
+
+
+@pytest.mark.releasetest
+def test_cli_autodocs_fresh() -> None:
+    assert os.path.exists(
+        _CLI_DOC_FILEPATH
+    ), f"Missing auto-generated CLI doc at {_CLI_DOC_FILEPATH}. Please run `make render-cli-doc` and commit the changes."
+    import sys
+
+    sys.path.append(_RENDER_DOC_SCRIPT_FILEPATH)
+    from build_scripts.render_cli_markdown import get_markdown_lines
+
+    expected_markdown_lines = [line.rstrip() for line in get_markdown_lines()]
+
+    with open(_CLI_DOC_FILEPATH, "r") as f:
+        actual_markdown_lines = [line.rstrip() for line in f.readlines()] + [""]
+
+    assert (
+        actual_markdown_lines == expected_markdown_lines
+    ), f"Current state of {_CLI_DOC_FILEPATH} is out of date.  Please run `make render-cli-doc` and commit the changes."

--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -5,3 +5,4 @@ pylint==3.3.3
 pytest==8.3.4
 pytest-cov==6.0.0
 coverage-badge==1.1.2
+mkdocs-click==0.8.1


### PR DESCRIPTION
## What?
* Adds automatic generation of -- and associated deploy test for -- the CLI reference markdown doc
* Closes #39 
