### PR TITLE
bump rebrowser to 1.49.1 and reduce docker size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
-FROM python:3.12.8-slim
-
-COPY ./requirements.txt ./tests/test-requirements.txt /
-RUN pip install -r /requirements.txt --timeout=300 --no-cache-dir
-RUN rebrowser_playwright install --with-deps chromium 
-
-ARG BUILD_ENV="test" PLASTERED_RELEASE_TAG=""
-RUN if [ "$BUILD_ENV" = "test" ]; then pip install -r /test-requirements.txt; fi
-RUN rm -rf /var/lib/apt/lists/*
+FROM python:3.12.8-slim AS app-builder
 
 WORKDIR /app
+COPY ./requirements.txt ./tests/test-requirements.txt /
+ARG BUILD_ENV="test" PLASTERED_RELEASE_TAG=""
+RUN if [ "$BUILD_ENV" = "test" ]; then pip install --no-cache-dir -r /test-requirements.txt; fi \
+    && pip install --no-cache-dir -r /requirements.txt --timeout=300 \
+    && rm -rf /root/.cache/pip
+RUN rebrowser_playwright install --with-deps chromium-headless-shell \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /root/.cache/ms-playwright/ffmpeg-1010 \
+    && find /usr/share/fonts/truetype -type f -name '*.ttc' -o -name '*.ttf' -o -name '*.otf' -delete
+COPY . .
 ENV APP_DIR=/app FORCE_COLOR=1 PLASTERED_RELEASE_TAG=${PLASTERED_RELEASE_TAG}
-ADD . .
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/plastered/scraper/lfm_scraper.py
+++ b/plastered/scraper/lfm_scraper.py
@@ -284,6 +284,7 @@ class LFMRecsScraper:
             else TRACK_REC_LIST_ELEMENT_CSS_SELECTOR
         )
         recs_page_locator = self._page.locator(wait_css_selector)  # pylint: disable=unused-variable
+        recs_page_locator.first.wait_for()
         _sleep_random()
         return self._page.content()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plastered"
-version = "0.1.0"
+version = "0.1.1"
 requires-python = ">= 3.12"
 
 [tool.black]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ urllib3==2.2.3
 tqdm==4.67.1
 PyYAML==6.0.2
 questionary==2.1.0
-rebrowser-playwright==1.47.0
+rebrowser-playwright==1.49.1
 rich==13.9.4

--- a/tests/scraper_tests/test_lfm_scraper.py
+++ b/tests/scraper_tests/test_lfm_scraper.py
@@ -570,6 +570,7 @@ def test_navigate_to_page_and_get_page_source(
             [
                 call.goto(fake_url, wait_until="domcontentloaded"),
                 call.locator(expected_css_selector),
+                call.locator().first.wait_for(),
                 call.content(),
             ]
         )


### PR DESCRIPTION
## What?
* Bump rebrowser-playwright to 1.49.1
* Refactor Dockerfile to reduce image size by ~200MB
* Add more robust recs locator waits

