### PR TITLE
Replace isort, pylint, black with ruff

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,28 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "pip"
+    directory: "/"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 2
+    groups:  # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates
+      app-dependencies:
+        depedency-type: "app"
+        applies-to: version-updates
+        exclude-patterns:
+          - "bandit"
+          - "pytest*"
+          - "ruff"
+          - "coverage-badge"
+          - "mkdocs-click"
+      test-dependencies:
+        dependency-type: "test"
+        applies-to: version-updates
+        pattern:
+          - "bandit"
+          - "pytest*"
+          - "ruff"
+          - "coverage-badge"
+        exclude-patterns:
+          - "mkdocs-click"

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+*ruff_cache
 
 # MacOS bullshit
 *.DS_Store

--- a/build_scripts/code-format.sh
+++ b/build_scripts/code-format.sh
@@ -8,20 +8,16 @@ else
 fi
 
 export PYTHONPATH="${APP_DIR}/plastered/"
-# isort_config_filepath=$(isort . --show-config | jq -r -c '..|.source? | select( . != null and . != "defaults" and . != "black profile")')
-# isort_target_paths=$(isort . --show-config | jq -r -c '. | .src_paths?')
 if [[ -z "${GITHUB_ACTIONS}" ]]; then
     echo "Not running in a github actions environment"
     cd /project_src_mnt
 fi
 if [[ "$CHECK" == "1" ]]; then
-    black --check .
-    isort --check .
-    pylint --rcfile ./pyproject.toml plastered
+    ruff check
+    ruff format --check
     bandit -c ./pyproject.toml -r . --severity-level all -n 1
 else
-    black .
-    isort .
-    pylint --rcfile ./pyproject.toml plastered
+    ruff check --fix
+    ruff format
     bandit -c ./pyproject.toml -r . --severity-level all -n 1
 fi

--- a/build_scripts/render_cli_markdown.py
+++ b/build_scripts/render_cli_markdown.py
@@ -24,10 +24,7 @@ def get_markdown_lines() -> list[str]:
         :command: cli
     """
     ).rstrip()
-    mkdocs_options = {
-        "module": "plastered.cli",
-        "command": "cli",
-    }
+    mkdocs_options = {"module": "plastered.cli", "command": "cli"}
     # adopted from mkdocs_click internals here:
     # https://github.com/mkdocs/mkdocs-click/blob/master/mkdocs_click/_extension.py#L55
     raw_markdown_lines = list(

--- a/plastered/cli.py
+++ b/plastered/cli.py
@@ -15,21 +15,9 @@ from plastered.release_search.release_searcher import ReleaseSearcher
 from plastered.run_cache.run_cache import CacheType, RunCache
 from plastered.scraper.lfm_scraper import LFMRecsScraper, RecommendationType
 from plastered.stats.stats import PriorRunStats
-from plastered.utils.cli_utils import (
-    DEFAULT_VERBOSITY,
-    StatsRunPicker,
-    config_path_option,
-    subcommand_flag,
-)
-from plastered.utils.constants import (
-    CACHE_TYPE_API,
-    CACHE_TYPE_SCRAPER,
-    RUN_DATE_STR_FORMAT,
-)
-from plastered.utils.exceptions import (
-    RunCacheDisabledException,
-    StatsRunPickerException,
-)
+from plastered.utils.cli_utils import DEFAULT_VERBOSITY, StatsRunPicker, config_path_option, subcommand_flag
+from plastered.utils.constants import CACHE_TYPE_API, CACHE_TYPE_SCRAPER, RUN_DATE_STR_FORMAT
+from plastered.utils.exceptions import RunCacheDisabledException, StatsRunPickerException
 from plastered.utils.log_utils import DATE_FORMAT, FORMAT, create_rich_log_handler
 from plastered.version import get_project_version
 
@@ -47,11 +35,7 @@ _CLI_ALL_CACHE_TYPES = "@all"
     context_settings={"auto_envvar_prefix": _OPTION_ENVVAR_PREFIX},
     help="plastered: Finds your LFM recs and snatches them from RED.",
 )
-@click.version_option(
-    version=_APP_VERSION,
-    package_name="plastered",
-    prog_name="plastered",
-)
+@click.version_option(version=_APP_VERSION, package_name="plastered", prog_name="plastered")
 @click.option(
     "-v",
     "--verbosity",
@@ -138,7 +122,7 @@ def inspect_stats(ctx, config: str, run_date: datetime | None = None) -> None:
                 date_str_format=RUN_DATE_STR_FORMAT,
             ).get_run_date_from_user_prompts()
         except StatsRunPickerException:
-            _LOGGER.error(f"No run prior run summaries available for inspection.")
+            _LOGGER.error("No run prior run summaries available for inspection.")
             ctx.exit(2)
     PriorRunStats(app_config=app_config, run_date=run_date).print_summary_tables()
 

--- a/plastered/config/config_schema.py
+++ b/plastered/config/config_schema.py
@@ -37,13 +37,7 @@ DEFAULTS_DICT = {
     "min_allowed_ratio": -1.0,
 }
 FORMAT_PREFERENCES_KEY = "format_preferences"
-EXPECTED_TOP_LEVEL_CLI_KEYS = set(
-    [
-        CLI_RED_KEY,
-        CLI_LFM_KEY,
-        CLI_SNATCHES_KEY,
-    ]
-)
+EXPECTED_TOP_LEVEL_CLI_KEYS = set([CLI_RED_KEY, CLI_LFM_KEY, CLI_SNATCHES_KEY])
 OPTIONAL_TOP_LEVEL_CLI_KEYS = set([CLI_SEARCH_KEY])
 # Sub-key constants
 PER_PREFERENCE_KEY = "preference"
@@ -101,26 +95,13 @@ required_schema = {
                     "type": "array",
                     "minItems": 1,
                     "maxItems": 2,
-                    "items": {
-                        "type": "string",
-                        "enum": ["album", "track"],
-                    },
+                    "items": {"type": "string", "enum": ["album", "track"]},
                     "default": DEFAULTS_DICT[REC_TYPES_TO_SCRAPE_KEY],
                 },
-                "allow_library_items": {
-                    "type": "boolean",
-                    "default": DEFAULTS_DICT["allow_library_items"],
-                },
-                "enable_scraper_cache": {
-                    "type": "boolean",
-                    "default": DEFAULTS_DICT["enable_scraper_cache"],
-                },
+                "allow_library_items": {"type": "boolean", "default": DEFAULTS_DICT["allow_library_items"]},
+                "enable_scraper_cache": {"type": "boolean", "default": DEFAULTS_DICT["enable_scraper_cache"]},
             },
-            "required": [
-                "lfm_api_key",
-                "lfm_username",
-                "lfm_password",
-            ],
+            "required": ["lfm_api_key", "lfm_username", "lfm_password"],
         },
         CLI_MUSICBRAINZ_KEY: {
             "type": "object",
@@ -136,10 +117,7 @@ required_schema = {
                 "use_first_release_year": {"type": "boolean", "default": DEFAULTS_DICT["use_first_release_year"]},
                 "use_record_label": {"type": "boolean", "default": DEFAULTS_DICT["use_record_label"]},
                 "use_catalog_number": {"type": "boolean", "default": DEFAULTS_DICT["use_catalog_number"]},
-                "enable_api_cache": {
-                    "type": "boolean",
-                    "default": DEFAULTS_DICT["enable_api_cache"],
-                },
+                "enable_api_cache": {"type": "boolean", "default": DEFAULTS_DICT["enable_api_cache"]},
             },
         },
         CLI_SNATCHES_KEY: {
@@ -166,25 +144,16 @@ required_schema = {
                     PER_PREFERENCE_KEY: {
                         "type": "object",
                         "properties": {
-                            FORMAT_KEY: {
-                                "type": "string",
-                                "enum": [format_enum.value for format_enum in FormatEnum],
-                            },
+                            FORMAT_KEY: {"type": "string", "enum": [format_enum.value for format_enum in FormatEnum]},
                             ENCODING_KEY: {
                                 "type": "string",
                                 "enum": [encoding_enum.value for encoding_enum in EncodingEnum],
                             },
-                            MEDIA_KEY: {
-                                "type": "string",
-                                "enum": [media_enum.value for media_enum in MediaEnum],
-                            },
+                            MEDIA_KEY: {"type": "string", "enum": [media_enum.value for media_enum in MediaEnum]},
                             CD_ONLY_EXTRAS_KEY: {
                                 "type": "object",
                                 "properties": {
-                                    LOG_KEY: {
-                                        "type": "integer",
-                                        "enum": LOG_ENUMS,
-                                    },
+                                    LOG_KEY: {"type": "integer", "enum": LOG_ENUMS},
                                     CUE_KEY: {"type": "boolean"},
                                 },
                                 "required": [LOG_KEY, CUE_KEY],
@@ -194,16 +163,9 @@ required_schema = {
                             "properties": {MEDIA_KEY: {"const": MediaEnum.CD.value}},
                             "required": [FORMAT_KEY, ENCODING_KEY, MEDIA_KEY],
                         },
-                        "then": {
-                            "required": [
-                                FORMAT_KEY,
-                                ENCODING_KEY,
-                                MEDIA_KEY,
-                                CD_ONLY_EXTRAS_KEY,
-                            ],
-                        },
+                        "then": {"required": [FORMAT_KEY, ENCODING_KEY, MEDIA_KEY, CD_ONLY_EXTRAS_KEY]},
                         "else": {"required": [FORMAT_KEY, ENCODING_KEY, MEDIA_KEY]},
-                    },
+                    }
                 },
             },
             "minItems": 1,

--- a/plastered/release_search/release_searcher.py
+++ b/plastered/release_search/release_searcher.py
@@ -14,12 +14,7 @@ from plastered.utils.httpx_utils.musicbrainz_client import MusicBrainzAPIClient
 from plastered.utils.httpx_utils.red_client import RedAPIClient
 from plastered.utils.httpx_utils.red_snatch_client import RedSnatchAPIClient
 from plastered.utils.lfm_utils import LFMAlbumInfo, LFMTrackInfo
-from plastered.utils.log_utils import (
-    CONSOLE,
-    SPINNER,
-    NestedProgress,
-    red_browse_progress,
-)
+from plastered.utils.log_utils import CONSOLE, SPINNER, NestedProgress, red_browse_progress
 from plastered.utils.musicbrainz_utils import MBRelease
 from plastered.utils.red_utils import RedUserDetails, ReleaseEntry
 
@@ -132,8 +127,7 @@ class ReleaseSearcher:
     def _resolve_lfm_album_info(self, si: SearchItem) -> LFMAlbumInfo:
         return LFMAlbumInfo.construct_from_api_response(
             json_blob=self._lfm_client.request_api(
-                method="album.getinfo",
-                params=f"artist={si.lfm_rec.artist_str}&album={si.lfm_rec.entity_str}",
+                method="album.getinfo", params=f"artist={si.lfm_rec.artist_str}&album={si.lfm_rec.entity_str}"
             )
         )
 
@@ -147,8 +141,7 @@ class ReleaseSearcher:
         _LOGGER.debug(f"Resolving LFM track info for {str(si)} ({si.lfm_rec.lfm_entity_url}) ...")
         try:
             lfm_api_response = self._lfm_client.request_api(
-                method="track.getinfo",
-                params=f"artist={si.lfm_rec.artist_str}&track={si.lfm_rec.entity_str}",
+                method="track.getinfo", params=f"artist={si.lfm_rec.artist_str}&track={si.lfm_rec.entity_str}"
             )
             if lfm_api_response and "album" in lfm_api_response:
                 resolved_track_info = LFMTrackInfo.construct_from_api_response(json_blob=lfm_api_response)
@@ -211,7 +204,7 @@ class ReleaseSearcher:
         Updates the SearchState with the valid and/or skipped recs as it searches.
         """
         if not search_items:
-            _LOGGER.warning(f"Input search_items list is empty. Skipping search.")
+            _LOGGER.warning("Input search_items list is empty. Skipping search.")
             return
         rec_type = search_items[0].lfm_rec.rec_type
         if not all([si.lfm_rec.rec_type == rec_type for si in search_items]):
@@ -230,7 +223,7 @@ class ReleaseSearcher:
         the search criteria for the given SearchItem.
         """
         if not search_items:
-            _LOGGER.warning(f"Input search_items list is empty. Skipping search.")
+            _LOGGER.warning("Input search_items list is empty. Skipping search.")
             return
         resolved_track_search_items = []
         # with Progress(*prog_args(), **prog_kwargs()) as progress:
@@ -248,11 +241,11 @@ class ReleaseSearcher:
         self._gather_red_user_details()
         if RecommendationType.ALBUM in rec_type_to_recs_list:
             self._search(
-                search_items=[SearchItem(lfm_rec=rec) for rec in rec_type_to_recs_list[RecommendationType.ALBUM]],
+                search_items=[SearchItem(lfm_rec=rec) for rec in rec_type_to_recs_list[RecommendationType.ALBUM]]
             )
         if RecommendationType.TRACK in rec_type_to_recs_list:
             self._search_for_track_recs(
-                search_items=[SearchItem(lfm_rec=rec) for rec in rec_type_to_recs_list[RecommendationType.TRACK]],
+                search_items=[SearchItem(lfm_rec=rec) for rec in rec_type_to_recs_list[RecommendationType.TRACK]]
             )
         if self._run_cache.enabled:
             self._run_cache.close()
@@ -260,7 +253,7 @@ class ReleaseSearcher:
 
     def _snatch_matches(self) -> None:
         if not self._enable_snatches:
-            _LOGGER.warning(f"Not configured to snatch. Please update your config to enable.")
+            _LOGGER.warning("Not configured to snatch. Please update your config to enable.")
             return
         if search_items_to_snatch := self._search_state.get_search_items_to_snatch():
             _LOGGER.debug(f"Beginning to snatch matched torrents to download directory '{self._snatch_directory}' ...")
@@ -269,7 +262,7 @@ class ReleaseSearcher:
                 for si_to_snatch in progress.track(search_items_to_snatch, description="Snatching matched torrents"):
                     self._snatch_match(si_to_snatch=si_to_snatch)
         else:
-            _LOGGER.warning(f"No torrents matched to your LFM recs. Consider adjusting the search config preferences.")
+            _LOGGER.warning("No torrents matched to your LFM recs. Consider adjusting the search config preferences.")
             return
 
     def _snatch_match(self, si_to_snatch: SearchItem) -> None:

--- a/plastered/release_search/search_helpers.py
+++ b/plastered/release_search/search_helpers.py
@@ -6,11 +6,7 @@ from urllib.parse import quote_plus
 
 from plastered.config.config_parser import AppConfig
 from plastered.scraper.lfm_scraper import LFMRec, RecContext, RecommendationType
-from plastered.stats.stats import (
-    SkippedReason,
-    SnatchFailureReason,
-    print_and_save_all_searcher_stats,
-)
+from plastered.stats.stats import SkippedReason, SnatchFailureReason, print_and_save_all_searcher_stats
 from plastered.utils.constants import (
     OPTIONAL_RED_PARAMS,
     RED_PARAM_CATALOG_NUMBER,
@@ -180,7 +176,7 @@ class SearchState:
         Updates the relevant information related to the RedUserDetails instance provided.
         """
         self._max_download_allowed_gb = red_user_details.calculate_max_download_allowed_gb(
-            min_allowed_ratio=self._min_allowed_ratio,
+            min_allowed_ratio=self._min_allowed_ratio
         )
         self._red_user_details = red_user_details
 
@@ -195,7 +191,7 @@ class SearchState:
         # TODO: figure out why the `order_by` param appears to be ignored whenever the params also have `group_results=1`.
         browse_request_params = f"artistname={artist_name}&groupname={album_name}&format={format}&encoding={encoding}&media={media}&group_results=1&order_by=seeders&order_way=desc"
         for red_param in OPTIONAL_RED_PARAMS:
-            if red_param in self._required_red_search_kwargs:
+            if red_param in self._required_red_search_kwargs:  # noqa: SIM102
                 if red_param_val := si.get_search_kwargs().get(red_param):
                     browse_request_params += f"&{red_param}={red_param_val}"
         return browse_request_params
@@ -289,7 +285,7 @@ class SearchState:
             self._add_skipped_snatch_row(si=si, reason=skip_reason)
             return False
         # Check whether the match is tied to a release which is already pending snatching during this run
-        if self._post_search_rule_dupe_snatch(si=si):
+        if self._post_search_rule_dupe_snatch(si=si):  # noqa: SIM103
             return False
         return True
 

--- a/plastered/scraper/lfm_scraper.py
+++ b/plastered/scraper/lfm_scraper.py
@@ -221,21 +221,20 @@ class LFMRecsScraper:
     def __enter__(self):
         for rec_type in self._rec_types_to_scrape:
             self._loaded_from_run_cache[rec_type] = self._run_cache.load_data_if_valid(
-                cache_key=rec_type.value,
-                data_validator_fn=cached_lfm_recs_validator,
+                cache_key=rec_type.value, data_validator_fn=cached_lfm_recs_validator
             )
         if all([cached_recs is not None for _, cached_recs in self._loaded_from_run_cache.items()]):
-            _LOGGER.info(f"Scraper cache enabled and cache hit successful for all enabled rec types.")
-            _LOGGER.info(f"Skipping scraper browser initialization.")
+            _LOGGER.info("Scraper cache enabled and cache hit successful for all enabled rec types.")
+            _LOGGER.info("Skipping scraper browser initialization.")
             return self
         with CONSOLE.status("Initializing LFM scraper ...", spinner=SPINNER):
-            _LOGGER.info(f"Initializing LFM scraper ...")
+            _LOGGER.info("Initializing LFM scraper ...")
             self._playwright = sync_playwright().start()
-            _LOGGER.info(f"Initializing headless chromium browser ...")
+            _LOGGER.info("Initializing headless chromium browser ...")
             self._browser = self._playwright.chromium.launch(headless=True)
-            _LOGGER.info(f"Opening new page in headless chromium browser ...")
+            _LOGGER.info("Opening new page in headless chromium browser ...")
             self._page = self._browser.new_page(user_agent=PW_USER_AGENT)
-            _LOGGER.info(f"Attempting Last.fm user login ...")
+            _LOGGER.info("Attempting Last.fm user login ...")
             self._user_login()
         return self
 
@@ -253,23 +252,23 @@ class LFMRecsScraper:
             self._playwright.stop()
 
     def _user_login(self) -> None:
-        _LOGGER.debug(f"Attempting login ...")
-        _LOGGER.info(f"Accessing login url ...")
+        _LOGGER.debug("Attempting login ...")
+        _LOGGER.info("Accessing login url ...")
         self._page.goto(LOGIN_URL, wait_until="domcontentloaded")
-        _LOGGER.debug(f"Locating username form ...")
+        _LOGGER.debug("Locating username form ...")
         self._page.locator(LOGIN_USERNAME_FORM_LOCATOR).fill(self._lfm_username)
-        _LOGGER.debug(f"Locating password form ...")
+        _LOGGER.debug("Locating password form ...")
         self._page.locator(LOGIN_PASSWORD_FORM_LOCATOR).fill(self._lfm_password)
-        _LOGGER.debug(f"Locating login button ...")
+        _LOGGER.debug("Locating login button ...")
         self._page.locator(LOGIN_BUTTON_LOCATOR).click()
-        _LOGGER.info(f"Waiting for successful login ...")
-        _LOGGER.debug(f"Calling sleep_random ...")
+        _LOGGER.info("Waiting for successful login ...")
+        _LOGGER.debug("Calling sleep_random ...")
         _sleep_random()
         self._is_logged_in = True
         _LOGGER.debug(f"Current driver page URL: {self._page.url}")
 
     def _user_logout(self) -> None:
-        _LOGGER.debug(f"Logging out from last.fm account ...")
+        _LOGGER.debug("Logging out from last.fm account ...")
         self._page.goto(LOGOUT_URL, wait_until="domcontentloaded")
         self._page.get_by_role("button", name=re.compile("logout", re.IGNORECASE)).locator("visible=true").first.click()
         self._is_logged_in = False
@@ -335,7 +334,7 @@ class LFMRecsScraper:
                 recs_page_source = self._navigate_to_page_and_get_page_source(url=recs_page_url, rec_type=rec_type)
                 recs.extend(self._extract_recs_from_page_source(page_source=recs_page_source, rec_type=rec_type))
         if self._run_cache.enabled:
-            _LOGGER.debug(f"Attempting cache write for scraper ...")
+            _LOGGER.debug("Attempting cache write for scraper ...")
             cache_write_success = self._run_cache.write_data(cache_key=rec_type.value, data=recs)
             _LOGGER.debug(f"Scraper cache write: {cache_write_success}")
         return recs

--- a/plastered/utils/cli_utils.py
+++ b/plastered/utils/cli_utils.py
@@ -119,17 +119,12 @@ class StatsRunPicker:
         ]
         if len(candidate_run_dts) <= 10:
             final_date_str = questionary.select(
-                f"Choose the run date:",
+                "Choose the run date:",
                 choices=sorted([dt.strftime(format=self._date_str_format) for dt in candidate_run_dts]),
             ).ask()
             return datetime.strptime(final_date_str, self._date_str_format)
         input_minute = self._prompt_date_component(dt_attr_name="minute")
         input_second = self._prompt_date_component(dt_attr_name="second")
         return datetime(
-            year=input_year,
-            month=input_month,
-            day=input_day,
-            hour=input_hour,
-            minute=input_minute,
-            second=input_second,
+            year=input_year, month=input_month, day=input_day, hour=input_hour, minute=input_minute, second=input_second
         )

--- a/plastered/utils/constants.py
+++ b/plastered/utils/constants.py
@@ -1,56 +1,60 @@
 from typing import Final
 
-RED_API_BASE_URL = "https://redacted.sh/ajax.php"
-LFM_API_BASE_URL = "https://ws.audioscrobbler.com/2.0/"
-MUSICBRAINZ_API_BASE_URL = "https://musicbrainz.org/ws/2/"
+RED_API_BASE_URL: Final[str] = "https://redacted.sh/ajax.php"
+LFM_API_BASE_URL: Final[str] = "https://ws.audioscrobbler.com/2.0/"
+MUSICBRAINZ_API_BASE_URL: Final[str] = "https://musicbrainz.org/ws/2/"
 
-RED_JSON_RESPONSE_KEY = "response"
+RED_JSON_RESPONSE_KEY: Final[str] = "response"
 
-CACHE_DIRNAME = "cache"
-API_CACHE_DIRNAME = "api_cache"
-SCRAPER_CACHE_DIRNAME = "scraper_cache"
-CACHE_TYPE_API = "api"
-CACHE_TYPE_SCRAPER = "scraper"
+CACHE_DIRNAME: Final[str] = "cache"
+API_CACHE_DIRNAME: Final[str] = "api_cache"
+SCRAPER_CACHE_DIRNAME: Final[str] = "scraper_cache"
+CACHE_TYPE_API: Final[str] = "api"
+CACHE_TYPE_SCRAPER: Final[str] = "scraper"
 
-PERMITTED_RED_API_ENDPOINTS = set(["browse", "torrentgroup", "community_stats", "user_torrents", "user"])
-NON_CACHED_RED_API_ENDPOINTS = set(["community_stats", "user_torrents", "user"])
+PERMITTED_RED_API_ENDPOINTS: Final[frozenset[str]] = frozenset(
+    ["browse", "torrentgroup", "community_stats", "user_torrents", "user"]
+)
+NON_CACHED_RED_API_ENDPOINTS: Final[frozenset[str]] = frozenset(["community_stats", "user_torrents", "user"])
 
-PERMITTED_RED_SNATCH_API_ENDPOINTS = set(["download"])
-NON_CACHED_RED_SNATCH_API_ENDPOINTS = set(["download"])
+PERMITTED_RED_SNATCH_API_ENDPOINTS: Final[frozenset[str]] = frozenset(["download"])
+NON_CACHED_RED_SNATCH_API_ENDPOINTS: Final[frozenset[str]] = frozenset(["download"])
 
-PERMITTED_LFM_API_ENDPOINTS = set(["album.getinfo", "track.getinfo"])
-PERMITTED_MUSICBRAINZ_API_ENDPOINTS = set(["release", "recording"])
+PERMITTED_LFM_API_ENDPOINTS: Final[frozenset[str]] = frozenset(["album.getinfo", "track.getinfo"])
+PERMITTED_MUSICBRAINZ_API_ENDPOINTS: Final[frozenset[str]] = frozenset(["release", "recording"])
 
-RENDER_WAIT_SEC_MIN = 3
-RENDER_WAIT_SEC_MAX = 7
+RENDER_WAIT_SEC_MIN: Final[int] = 3
+RENDER_WAIT_SEC_MAX: Final[int] = 7
 
-PW_USER_AGENT = "Mozilla/5.0 (Linux; Android 14; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.6099.28 Mobile Safari/537.36"
+PW_USER_AGENT: Final[str] = (
+    "Mozilla/5.0 (Linux; Android 14; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.6099.28 Mobile Safari/537.36"
+)
 
-ALBUM_RECS_BASE_URL = "https://www.last.fm/music/+recommended/albums"
-ALBUM_REC_LIST_ELEMENT_CSS_SELECTOR = ".music-recommended-albums-item-name"
-ALBUM_REC_LIST_ELEMENT_BS4_CSS_SELECTOR = ".music-recommended-albums-item-name a.link-block-target"
-ALBUM_REC_CONTEXT_BS4_CSS_SELECTOR = "p.music-recommended-albums-album-context"
+ALBUM_RECS_BASE_URL: Final[str] = "https://www.last.fm/music/+recommended/albums"
+ALBUM_REC_LIST_ELEMENT_CSS_SELECTOR: Final[str] = ".music-recommended-albums-item-name"
+ALBUM_REC_LIST_ELEMENT_BS4_CSS_SELECTOR: Final[str] = ".music-recommended-albums-item-name a.link-block-target"
+ALBUM_REC_CONTEXT_BS4_CSS_SELECTOR: Final[str] = "p.music-recommended-albums-album-context"
 
-TRACK_RECS_BASE_URL = "https://www.last.fm/music/+recommended/tracks"
-TRACK_REC_LIST_ELEMENT_CSS_SELECTOR = ".recommended-tracks-item-name"
-TRACK_REC_LIST_ELEMENT_BS4_CSS_SELECTOR = ".recommended-tracks-item-name a.link-block-target"
-TRACK_REC_CONTEXT_CSS_SELECTOR = "p.recommended-tracks-item-aux-text.recommended-tracks-item-context"
+TRACK_RECS_BASE_URL: Final[str] = "https://www.last.fm/music/+recommended/tracks"
+TRACK_REC_LIST_ELEMENT_CSS_SELECTOR: Final[str] = ".recommended-tracks-item-name"
+TRACK_REC_LIST_ELEMENT_BS4_CSS_SELECTOR: Final[str] = ".recommended-tracks-item-name a.link-block-target"
+TRACK_REC_CONTEXT_CSS_SELECTOR: Final[str] = "p.recommended-tracks-item-aux-text.recommended-tracks-item-context"
 
-LOGIN_URL = "https://www.last.fm/login"
-LOGIN_USERNAME_FORM_LOCATOR = "[name='username_or_email']"
-LOGIN_PASSWORD_FORM_LOCATOR = "[name='password']"  # nosec B105
-LOGIN_BUTTON_LOCATOR = "[name='submit']"
-LOGOUT_URL = "https://www.last.fm/logout"
+LOGIN_URL: Final[str] = "https://www.last.fm/login"
+LOGIN_USERNAME_FORM_LOCATOR: Final[str] = "[name='username_or_email']"
+LOGIN_PASSWORD_FORM_LOCATOR: Final[str] = "[name='password']"  # nosec B105
+LOGIN_BUTTON_LOCATOR: Final[str] = "[name='submit']"
+LOGOUT_URL: Final[str] = "https://www.last.fm/logout"
 
 RUN_DATE_STR_FORMAT = "%Y-%m-%d__%H-%M-%S"
 
-STORAGE_UNIT_IDENTIFIERS = ["B", "MB", "GB"]
-BYTES_IN_GB: Final[float] = float(1e9)
-BYTES_IN_MB: Final[float] = float(1e6)
+STORAGE_UNIT_IDENTIFIERS: Final[frozenset[str]] = frozenset(["B", "MB", "GB"])
+BYTES_IN_GB: Final[float] = 1e9
+BYTES_IN_MB: Final[float] = 1e6
 
 # TODO: consolidate these
-STATS_TRACK_REC_NONE = "N/A"
-STATS_NONE = "N/A"
+STATS_TRACK_REC_NONE: Final[str] = "N/A"
+STATS_NONE: Final[str] = "N/A"
 
 # User-specified params to optionally append to the RED browse requests
 RED_PARAM_RELEASE_TYPE: Final[str] = "releasetype"

--- a/plastered/utils/httpx_utils/musicbrainz_client.py
+++ b/plastered/utils/httpx_utils/musicbrainz_client.py
@@ -3,10 +3,7 @@ from urllib.parse import quote
 
 from plastered.config.config_parser import AppConfig
 from plastered.run_cache.run_cache import RunCache
-from plastered.utils.constants import (
-    MUSICBRAINZ_API_BASE_URL,
-    PERMITTED_MUSICBRAINZ_API_ENDPOINTS,
-)
+from plastered.utils.constants import MUSICBRAINZ_API_BASE_URL, PERMITTED_MUSICBRAINZ_API_ENDPOINTS
 from plastered.utils.httpx_utils.base_client import LOGGER, ThrottledAPIBaseClient
 
 

--- a/plastered/utils/httpx_utils/red_snatch_client.py
+++ b/plastered/utils/httpx_utils/red_snatch_client.py
@@ -41,13 +41,13 @@ class RedSnatchAPIClient(ThrottledAPIBaseClient):
     def set_initial_available_fl_tokens(self, initial_available_fl_tokens: int) -> None:
         self._available_fl_tokens = initial_available_fl_tokens
         if self._use_fl_tokens and self._available_fl_tokens == 0:
-            LOGGER.warning(f"Currently have zero RED FL tokens available. Ignoring 'use_fl_tokens' config setting.")
+            LOGGER.warning("Currently have zero RED FL tokens available. Ignoring 'use_fl_tokens' config setting.")
             self._use_fl_tokens = False
         elif self._use_fl_tokens and self._available_fl_tokens > 0:
             LOGGER.info(f"Configured to use FL tokens. Detected {self._available_fl_tokens} FL tokens available.")
         else:
             LOGGER.warning(
-                f"Will not use FL tokens. To enable FL token usage, set 'search.use_fl_tokens: true' in your config.yaml file."
+                "Will not use FL tokens. To enable FL token usage, set 'search.use_fl_tokens: true' in your config.yaml file."
             )
 
     def snatch(self, tid: str, can_use_token: bool) -> bytes:

--- a/plastered/utils/lfm_utils.py
+++ b/plastered/utils/lfm_utils.py
@@ -51,7 +51,7 @@ class LFMTrackInfo:
     def construct_from_api_response(cls, json_blob: dict[str, Any]):
         """Constructs an LFMTrackInfo instance from the LFM API's track.getinfo endpoint JSON response."""
         release_json = json_blob["album"]
-        release_mbid = None if "mbid" not in release_json else release_json["mbid"]
+        release_mbid = release_json.get("mbid", None)
         return cls(
             artist=json_blob["artist"]["name"],
             track_name=json_blob["name"],

--- a/plastered/utils/log_utils.py
+++ b/plastered/utils/log_utils.py
@@ -94,14 +94,10 @@ class NestedProgress(Progress):
 
     def get_renderables(self) -> Iterable[RenderableType]:
         for task in self.tasks:
-            if task.fields.get("progress_type") == ProgType.RED_BROWSE:
-                self.columns = (
-                    SpinnerColumn(),  # spinner_name=SPINNER),
-                    TextColumn("[progress.description]{task.description}"),
-                    BarColumn(BAR_WIDTH),
-                    TimeElapsedColumn(),
-                )
-            elif task.fields.get("progress_type") == ProgType.RED_SNATCH:
+            if (
+                task.fields.get("progress_type") == ProgType.RED_BROWSE
+                or task.fields.get("progress_type") == ProgType.RED_SNATCH
+            ):
                 self.columns = (
                     SpinnerColumn(),  # spinner_name=SPINNER),
                     TextColumn("[progress.description]{task.description}"),

--- a/plastered/utils/red_utils.py
+++ b/plastered/utils/red_utils.py
@@ -145,13 +145,7 @@ class RedFormat:
     """
 
     # pylint: disable=redefined-builtin
-    def __init__(
-        self,
-        format: FormatEnum,
-        encoding: EncodingEnum,
-        media: MediaEnum,
-        cd_only_extras: str | None = "",
-    ):
+    def __init__(self, format: FormatEnum, encoding: EncodingEnum, media: MediaEnum, cd_only_extras: str | None = ""):
         self._format = format
         self._encoding = encoding
         self._media = media
@@ -164,7 +158,7 @@ class RedFormat:
         entries = {"format": self._format.value, "encoding": self._encoding.value, "media": self._encoding.value}
         if self._cd_only_extras:
             log_str, cue_str = _CD_EXTRAS_PRETTY_PRINT_REGEX_PATTERN.findall(self._cd_only_extras)[0]
-            entries["cd_only_extras"] = {"log": int(log_str), "has_cue": True if int(cue_str) else False}
+            entries["cd_only_extras"] = {"log": int(log_str), "has_cue": bool(int(cue_str))}
         return {"preference": entries}
 
     def __hash__(self) -> int:
@@ -269,10 +263,7 @@ class TorrentEntry:
             return False
         self_attrs = vars(self)
         other_attrs = vars(other)
-        for attr_name, attr_val in self_attrs.items():
-            if other_attrs[attr_name] != attr_val:
-                return False
-        return True
+        return all([other_attrs[attr_name] == attr_val for attr_name, attr_val in self_attrs.items()])
 
     @classmethod
     def from_torrent_search_json_blob(cls, json_blob: dict[str, Any]):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,74 @@ name = "plastered"
 version = "0.2.0"
 requires-python = ">= 3.12"
 
-[tool.black]
+[tool.ruff]
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
 line-length = 120
+indent-width = 4
+
+
+# RUFF Linter
+[tool.ruff.lint]
+exclude = ["tests/**/*.py"]
+select = [
+    # pycodestyle
+    "E",
+    # Pyflakes
+    "F",
+    # pyupgrade
+    "UP",
+    # flake8-bugbear
+    "B",
+    # flake8-simplify
+    "SIM",
+    # isort
+    "I",
+]
+# This is to get the line length auto-formatting mostly handled https://stackoverflow.com/a/77796620
+ignore = ["E203", "E501"]
+
+[tool.ruff.lint.isort]
+# https://docs.astral.sh/ruff/settings/#lint_isort_split-on-trailing-comma
+split-on-trailing-comma = false
+
+[tool.ruff.lint.pycodestyle]
+# https://docs.astral.sh/ruff/rules/line-too-long/#why-is-this-bad
+ignore-overlong-task-comments = true
+
+# RUFF formatter
+[tool.ruff.format]
+# https://docs.astral.sh/ruff/settings/#format_skip-magic-trailing-comma
+skip-magic-trailing-comma = true
+# https://docs.astral.sh/ruff/settings/#format_docstring-code-format
+docstring-code-format = true
+
 
 # Pytest coverage configuration
 # https://coverage.readthedocs.io/en/latest/config.html
@@ -36,84 +102,6 @@ exclude_also = [
     # Don't complain about abstract methods, they aren't run:
     "@(abc\\.)?abstractmethod",
     ]
-
-[tool.isort]
-profile = "black"
-src_paths = ["plastered", "tests"]
-
-[tool.pylint.main]
-ignore-patterns = ["^\\.#"]
-py-version = "3.12"
-load-plugins = "pylint.extensions.typing"
-
-[tool.pylint.basic]
-no-docstring-rgx = "^_"
-
-# for a list the pylint messages and descriptions, see here since pylint docs are terrible: https://sprytnyk.github.io/pylint-errors/
-# TODO: enable protected-access
-[tool.pylint."MESSAGES CONTROL"]
-disable = ["all"]
-enable = """
-    abstract-class-instantiated,
-    abstract-method,
-    access-member-before-definition,
-    arguments-differ,
-    attribute-defined-outside-init,
-    bad-classmethod-argument,
-    bad-staticmethod-argument,
-    blacklisted-name,
-    comparison-with-callable,
-    comparison-with-itself,
-    cyclic-import,
-    deprecated-typing-alias,
-    duplicate-argument-name,
-    duplicate-bases,
-    duplicate-key,
-    eval-used,
-    exec-used,
-    expression-not-assigned,
-    function-redefined,
-    inherit-non-class,
-    init-is-generator,
-    invalid-name,
-    invalid-overridden-method,
-    literal-comparison,
-    method-hidden,
-    missing-class-docstring,
-    no-classmethod-decorator,
-    no-else-return,
-    no-method-argument,
-    no-self-argument,
-    no-staticmethod-decorator,
-    no-value-for-parameter,
-    nonexistent-operator,
-    non-parent-init-called,
-    not-in-loop,
-    not-async-context-manager,
-    pointless-statement,
-    property-with-parameters,
-    redeclared-assigned-name,
-    redefined-builtin,
-    redefined-outer-name,
-    return-in-init,
-    self-assigning-variable,
-    signature-differs,
-    super-init-not-called,
-    too-many-star-expressions,
-    unexpected-special-method-signature,
-    unidiomatic-typecheck,
-    unnecessary-lambda,
-    unnecessary-semicolon,
-    unreachable,
-    unused-argument,
-    unused-import,
-    unused-variable,
-    useless-object-inheritance,
-    yield-inside-async-function,
-"""
-
-[tool.pylint.variables]
-ignored-argument-names = "_.*|^ignored_|^unused_"
 
 [tool.pytest.ini_options]
 addopts = "--cov=plastered --no-cov-on-fail"

--- a/tests/cli_tests/test_cli.py
+++ b/tests/cli_tests/test_cli.py
@@ -10,25 +10,10 @@ from plastered.cli import cli
 from plastered.config.config_parser import AppConfig
 from plastered.release_search.release_searcher import ReleaseSearcher
 from plastered.run_cache.run_cache import RunCache
-from plastered.scraper.lfm_scraper import (
-    LFMRec,
-    LFMRecsScraper,
-    RecContext,
-    RecommendationType,
-)
+from plastered.scraper.lfm_scraper import LFMRec, LFMRecsScraper, RecContext, RecommendationType
 from plastered.utils.cli_utils import StatsRunPicker
 from plastered.utils.constants import RUN_DATE_STR_FORMAT
-from plastered.utils.exceptions import (
-    RunCacheDisabledException,
-    StatsRunPickerException,
-)
-from tests.conftest import (
-    api_run_cache,
-    mock_run_date_str,
-    scraper_run_cache,
-    valid_app_config,
-    valid_config_filepath,
-)
+from plastered.utils.exceptions import RunCacheDisabledException, StatsRunPickerException
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -91,7 +76,7 @@ def test_cli_conf_command(valid_config_filepath: str, mock_logger_set_level: Mag
                     LFMRec(
                         "Other+Fake+Artist", "Other+Fake+Album", RecommendationType.ALBUM, RecContext.SIMILAR_ARTIST
                     ),
-                ],
+                ]
             },
         ),
         (
@@ -102,7 +87,7 @@ def test_cli_conf_command(valid_config_filepath: str, mock_logger_set_level: Mag
                     LFMRec(
                         "Other+Faker+Artist", "Faker+Shittier+Track", RecommendationType.TRACK, RecContext.IN_LIBRARY
                     ),
-                ],
+                ]
             },
         ),
         (
@@ -140,9 +125,9 @@ def test_cli_scrape_command(
                     result = cli_runner.invoke(
                         cli, ["scrape", "--config", valid_config_filepath, "--rec-types", rec_types]
                     )
-                    assert (
-                        result.exit_code == 0
-                    ), f"Expected cli command 'scrape' to pass but errored: {result.exception}"
+                    assert result.exit_code == 0, (
+                        f"Expected cli command 'scrape' to pass but errored: {result.exception}"
+                    )
                     mock_enter.assert_called_once()
                     mock_scrape_recs.assert_called_once()
                     mock_exit.assert_called_once()
@@ -213,9 +198,9 @@ def test_cli_cache_command(
         mock_run_cache_constructor.side_effect = _mock_run_cache_init_side_effect
         cli_runner = CliRunner()
         result = cli_runner.invoke(cli, test_cmd)
-        assert (
-            result.exit_code == 0
-        ), f"Expected cli command '{' '.join(test_cmd)}' to pass but errored: {result.exception}"
+        assert result.exit_code == 0, (
+            f"Expected cli command '{' '.join(test_cmd)}' to pass but errored: {result.exception}"
+        )
         if cache_arg == "api":
             mock_api_run_cache_instance.assert_has_calls(expected_run_cache_calls)
         elif cache_arg == "scraper":
@@ -226,9 +211,7 @@ def test_cli_cache_command(
 
 
 def test_cli_cache_disabled_exception(
-    valid_config_filepath: str,
-    mock_api_run_cache_instance: MagicMock,
-    mock_scraper_run_cache_instance: MagicMock,
+    valid_config_filepath: str, mock_api_run_cache_instance: MagicMock, mock_scraper_run_cache_instance: MagicMock
 ) -> None:
     cli_runner = CliRunner()
     mock_api_run_cache_instance.check.side_effect = RunCacheDisabledException("")
@@ -256,11 +239,7 @@ def test_cli_init_conf_command() -> None:
 
 
 @pytest.mark.parametrize("run_date_provided", [False, True])
-def test_cli_inspect_stats_command(
-    valid_config_filepath: str,
-    mock_run_date_str: str,
-    run_date_provided: bool,
-) -> None:
+def test_cli_inspect_stats_command(valid_config_filepath: str, mock_run_date_str: str, run_date_provided: bool) -> None:
     test_cmd = ["inspect-stats", "--config", valid_config_filepath]
     if run_date_provided:
         test_cmd.append("--run-date")
@@ -278,10 +257,7 @@ def test_cli_inspect_stats_command(
             mock_prs_instance.print_summary_tables.assert_called_once()
 
 
-def test_cli_inspect_stats_command_exception(
-    valid_config_filepath: str,
-    mock_run_date_str: str,
-) -> None:
+def test_cli_inspect_stats_command_exception(valid_config_filepath: str, mock_run_date_str: str) -> None:
     test_cmd = ["inspect-stats", "--config", valid_config_filepath]
 
     def _prs_side_effect(*args, **kwargs) -> None:

--- a/tests/config_tests/test_config_parser.py
+++ b/tests/config_tests/test_config_parser.py
@@ -1,6 +1,6 @@
 import os
 from typing import Any
-from unittest.mock import call, mock_open, patch
+from unittest.mock import mock_open, patch
 
 import pytest
 
@@ -11,25 +11,10 @@ from plastered.config.config_parser import (
     _load_red_formats_from_config,
     load_init_config_template,
 )
-from plastered.config.config_schema import (
-    CLI_SNATCH_DIRECTORY_KEY,
-    FORMAT_PREFERENCES_KEY,
-)
+from plastered.config.config_schema import CLI_SNATCH_DIRECTORY_KEY, FORMAT_PREFERENCES_KEY
 from plastered.utils.exceptions import AppConfigException
 from plastered.utils.red_utils import RedFormat
-from tests.conftest import (
-    INVALID_CONFIGS_DIR_PATH,
-    MOCK_RESOURCES_DIR_PATH,
-    ROOT_MODULE_ABS_PATH,
-    expected_red_format_list,
-    minimal_valid_app_config,
-    minimal_valid_config_filepath,
-    minimal_valid_config_raw_data,
-    mock_run_date_str,
-    valid_app_config,
-    valid_config_filepath,
-    valid_config_raw_data,
-)
+from tests.conftest import INVALID_CONFIGS_DIR_PATH, MOCK_RESOURCES_DIR_PATH, ROOT_MODULE_ABS_PATH
 
 _EXPECTED_FORMAT_PREFERENCE_LENGTH = 6
 
@@ -41,7 +26,7 @@ def test_load_init_config_template() -> None:
         "builtins.open", new_callable=mock_open, read_data="# top comment\nline1: # inline-comment\n\tline2\n"
     ) as mock_open_builtin:
         actual_result = load_init_config_template()
-        mock_open_builtin.assert_called_once_with(expected_filepath_arg, "r")
+        mock_open_builtin.assert_called_once_with(expected_filepath_arg)
         assert actual_result == expected_result, f"Expected result: '{expected_result}', but got '{actual_result}'"
 
 
@@ -80,15 +65,15 @@ def test_load_red_formats_from_config(
     print(f"type(result[0]): {type(result[0])}")
     print(f"result[0].__class__.__name__: {result[0].__class__.__name__}")
     assert isinstance(result, list), f"Expected result type to be list, but got '{type(result)}'"
-    assert (
-        len(result) == _EXPECTED_FORMAT_PREFERENCE_LENGTH
-    ), f"Expected RedFormat list to contain {_EXPECTED_FORMAT_PREFERENCE_LENGTH} elements, but found {len(result)}"
-    assert all([isinstance(elem, RedFormat) for elem in result]), f"Expected all elements to be of class 'RedFormat'"
+    assert len(result) == _EXPECTED_FORMAT_PREFERENCE_LENGTH, (
+        f"Expected RedFormat list to contain {_EXPECTED_FORMAT_PREFERENCE_LENGTH} elements, but found {len(result)}"
+    )
+    assert all([isinstance(elem, RedFormat) for elem in result]), "Expected all elements to be of class 'RedFormat'"
     for i, actual_format in enumerate(result):
         expected_format = expected_red_format_list[i]
-        assert (
-            actual_format == expected_format
-        ), f"Unexpected RedFormat mismatch on {i}'th element of RedFormats list: expected: {expected_format}, actual: {actual_format}"
+        assert actual_format == expected_format, (
+            f"Unexpected RedFormat mismatch on {i}'th element of RedFormats list: expected: {expected_format}, actual: {actual_format}"
+        )
 
 
 @pytest.mark.parametrize(
@@ -128,9 +113,7 @@ def test_load_red_formats_from_config(
     ],
 )
 def test_invalid_dupe_load_red_formats_from_config(
-    mock_format_prefs_config_data: list[dict[str, Any]],
-    exception: Exception,
-    exception_msg: str,
+    mock_format_prefs_config_data: list[dict[str, Any]], exception: Exception, exception_msg: str
 ) -> None:
     with pytest.raises(exception, match=exception_msg):
         _load_red_formats_from_config(format_prefs_config_data=mock_format_prefs_config_data)
@@ -196,16 +179,16 @@ def test_app_config_constructor(
     app_config = AppConfig(config_filepath=valid_config_filepath, cli_params=cli_params)
     for opt_key, expected_value in expected_opts_vals.items():
         actual_value = app_config.get_cli_option(opt_key)
-        assert (
-            actual_value == expected_value
-        ), f"Unexpected '{opt_key}' value: '{actual_value}'. Expected '{expected_value}'"
+        assert actual_value == expected_value, (
+            f"Unexpected '{opt_key}' value: '{actual_value}'. Expected '{expected_value}'"
+        )
     # test the construction from the minimal valid config file
     app_config = AppConfig(config_filepath=minimal_valid_config_filepath, cli_params=cli_params)
     for opt_key, expected_value in expected_opts_vals.items():
         actual_value = app_config.get_cli_option(opt_key)
-        assert (
-            actual_value == expected_value
-        ), f"Unexpected '{opt_key}' value: '{actual_value}'. Expected '{expected_value}'"
+        assert actual_value == expected_value, (
+            f"Unexpected '{opt_key}' value: '{actual_value}'. Expected '{expected_value}'"
+        )
 
 
 @pytest.mark.parametrize(
@@ -269,26 +252,15 @@ def test_get_root_summary_directory_path(valid_config_filepath: str, valid_app_c
 
 @pytest.mark.parametrize("date_str_provided", [False, True])
 def test_get_output_summary_dir_path(
-    valid_config_filepath: str,
-    valid_app_config: AppConfig,
-    mock_run_date_str: str,
-    date_str_provided: bool,
+    valid_config_filepath: str, valid_app_config: AppConfig, mock_run_date_str: str, date_str_provided: bool
 ) -> None:
     valid_app_config._run_datestr = mock_run_date_str
     if not date_str_provided:
-        expected = os.path.join(
-            os.path.dirname(valid_config_filepath),
-            _SUMMARIES_DIRNAME,
-            mock_run_date_str,
-        )
+        expected = os.path.join(os.path.dirname(valid_config_filepath), _SUMMARIES_DIRNAME, mock_run_date_str)
         actual = valid_app_config.get_output_summary_dir_path()
     else:
         date_str_arg = "2024-01-01__00-10-45"
-        expected = os.path.join(
-            os.path.dirname(valid_config_filepath),
-            _SUMMARIES_DIRNAME,
-            date_str_arg,
-        )
+        expected = os.path.join(os.path.dirname(valid_config_filepath), _SUMMARIES_DIRNAME, date_str_arg)
         actual = valid_app_config.get_output_summary_dir_path(date_str=date_str_arg)
     assert actual == expected
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,9 @@ import csv
 import json
 import os
 import re
+from collections.abc import Generator
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any
 from unittest.mock import MagicMock
 
 import httpx
@@ -15,13 +16,7 @@ from pytest_httpx import HTTPXMock
 from plastered.run_cache.run_cache import CacheType, RunCache
 from plastered.stats.stats import SkippedReason, SnatchFailureReason
 from plastered.utils.musicbrainz_utils import MBRelease
-from plastered.utils.red_utils import (
-    EncodingEnum,
-    FormatEnum,
-    MediaEnum,
-    RedFormat,
-    RedUserDetails,
-)
+from plastered.utils.red_utils import EncodingEnum, FormatEnum, MediaEnum, RedFormat, RedUserDetails
 
 TEST_DIR_ABS_PATH = os.path.dirname(os.path.abspath(__file__))
 PROJECT_ABS_PATH = os.path.abspath(os.getenv("APP_DIR"))
@@ -94,7 +89,7 @@ def pytest_collection_modifyitems(config, items):
 
 def load_mock_response_json(json_filepath: str) -> dict[str, Any]:
     """Utility function to load and return the mock API json blob located at the specified json_filepath."""
-    with open(json_filepath, "r") as f:
+    with open(json_filepath) as f:
         json_data = json.load(f)
     return json_data
 
@@ -116,14 +111,14 @@ def minimal_valid_config_filepath() -> str:
 
 @pytest.fixture(scope="session")
 def valid_config_raw_data(valid_config_filepath: str) -> dict[str, Any]:
-    with open(valid_config_filepath, "r") as f:
+    with open(valid_config_filepath) as f:
         raw_config_data = yaml.safe_load(f.read())
     return raw_config_data
 
 
 @pytest.fixture(scope="session")
 def minimal_valid_config_raw_data(minimal_valid_config_filepath: str) -> dict[str, Any]:
-    with open(minimal_valid_config_filepath, "r") as f:
+    with open(minimal_valid_config_filepath) as f:
         raw_config_data = yaml.safe_load(f.read())
     return raw_config_data
 
@@ -238,15 +233,7 @@ def mock_summary_tsvs(
             "FL_token_used",
             "Snatch_path",
         ],
-        "skipped": [
-            "Type",
-            "LFM_Rec_context",
-            "Artist",
-            "Release",
-            "Track_Rec",
-            "Matched_RED_TID",
-            "Skip_reason",
-        ],
+        "skipped": ["Type", "LFM_Rec_context", "Artist", "Release", "Track_Rec", "Matched_RED_TID", "Skip_reason"],
     }
 
     def _write_dummy_tsv(dummy_path: str, header: list[str], dummy_rows: list[list[str]]) -> None:
@@ -261,18 +248,12 @@ def mock_summary_tsvs(
     _write_dummy_tsv(failed_tsv_path, type_to_headers["failed"], failed_snatch_rows)
     _write_dummy_tsv(snatched_tsv_path, type_to_headers["snatched"], snatch_summary_rows)
     _write_dummy_tsv(skipped_tsv_path, type_to_headers["skipped"], skipped_rows)
-    return {
-        "failed": failed_tsv_path,
-        "snatched": snatched_tsv_path,
-        "skipped": skipped_tsv_path,
-    }
+    return {"failed": failed_tsv_path, "snatched": snatched_tsv_path, "skipped": skipped_tsv_path}
 
 
 @pytest.fixture(scope="session")
 def mock_action_to_red_json_responses() -> dict[str, dict[str, Any]]:
-    return {
-        "browse": load_mock_response_json(json_filepath=_RED_MOCK_BROWSE_JSON_FILEPATH),
-    }
+    return {"browse": load_mock_response_json(json_filepath=_RED_MOCK_BROWSE_JSON_FILEPATH)}
 
 
 @pytest.fixture(scope="session")
@@ -668,25 +649,16 @@ def global_httpx_mock(
         for red_regex_and_json in red_url_regex_to_mock_json:
             request_url_pattern, resp_mock_json = red_regex_and_json
             httpx_mock.add_response(
-                url=re.compile(request_url_pattern),
-                json=resp_mock_json,
-                is_optional=True,
-                is_reusable=True,
+                url=re.compile(request_url_pattern), json=resp_mock_json, is_optional=True, is_reusable=True
             )
         for lfm_regex_and_json in lfm_url_regex_to_mock_json:
             request_url_pattern, resp_mock_json = lfm_regex_and_json
             httpx_mock.add_response(
-                url=re.compile(request_url_pattern),
-                json=resp_mock_json,
-                is_optional=True,
-                is_reusable=True,
+                url=re.compile(request_url_pattern), json=resp_mock_json, is_optional=True, is_reusable=True
             )
         for mb_regex_and_json in mb_url_regex_to_mock_json:
             request_url_pattern, resp_mock_json = mb_regex_and_json
             httpx_mock.add_response(
-                url=re.compile(request_url_pattern),
-                json=resp_mock_json,
-                is_optional=True,
-                is_reusable=True,
+                url=re.compile(request_url_pattern), json=resp_mock_json, is_optional=True, is_reusable=True
             )
         yield httpx_mock

--- a/tests/deploy_tests/test_cli_autodocs_fresh.py
+++ b/tests/deploy_tests/test_cli_autodocs_fresh.py
@@ -1,6 +1,6 @@
 """
 This file contains unit tests to ensure that the auto-generated markdown docs from the CLI help commands
-are properly in sync with the current CLI code. If not in sync, will error and indicates that the 
+are properly in sync with the current CLI code. If not in sync, will error and indicates that the
 `make render-cli-doc` command should be run and the changes committed.
 """
 
@@ -16,9 +16,9 @@ _RENDER_DOC_SCRIPT_FILEPATH = os.path.join(PROJECT_ABS_PATH, "build_scripts", "r
 
 @pytest.mark.releasetest
 def test_cli_autodocs_fresh() -> None:
-    assert os.path.exists(
-        _CLI_DOC_FILEPATH
-    ), f"Missing auto-generated CLI doc at {_CLI_DOC_FILEPATH}. Please run `make render-cli-doc` and commit the changes."
+    assert os.path.exists(_CLI_DOC_FILEPATH), (
+        f"Missing auto-generated CLI doc at {_CLI_DOC_FILEPATH}. Please run `make render-cli-doc` and commit the changes."
+    )
     import sys
 
     sys.path.append(_RENDER_DOC_SCRIPT_FILEPATH)
@@ -26,9 +26,9 @@ def test_cli_autodocs_fresh() -> None:
 
     expected_markdown_lines = [line.rstrip() for line in get_markdown_lines()]
 
-    with open(_CLI_DOC_FILEPATH, "r") as f:
+    with open(_CLI_DOC_FILEPATH) as f:
         actual_markdown_lines = [line.rstrip() for line in f.readlines()] + [""]
 
-    assert (
-        actual_markdown_lines == expected_markdown_lines
-    ), f"Current state of {_CLI_DOC_FILEPATH} is out of date.  Please run `make render-cli-doc` and commit the changes."
+    assert actual_markdown_lines == expected_markdown_lines, (
+        f"Current state of {_CLI_DOC_FILEPATH} is out of date.  Please run `make render-cli-doc` and commit the changes."
+    )

--- a/tests/deploy_tests/test_deploy_version_ids.py
+++ b/tests/deploy_tests/test_deploy_version_ids.py
@@ -1,5 +1,5 @@
 """
-This file contains unit tests to ensure that the 
+This file contains unit tests to ensure that the
 git release tag and the semver id in pyproject.toml are in alignment and both valid.
 """
 
@@ -30,17 +30,17 @@ def github_release_tag() -> str:
 # TODO: add unit test to check that the `plastered --version` output is also in sync (maybe in the test_cli.py file ?)
 @pytest.mark.releasetest
 def test_version_id_and_git_tag_match(pyproject_toml_data: dict[str, Any], github_release_tag: str | None) -> None:
-    assert (
-        github_release_tag is not None
-    ), f"Expected a non-empty string value for '{_GITHUB_RELEASE_TAG_ENV_VAR}' environment variable, but got None."
-    assert (
-        len(github_release_tag) > 0
-    ), f"Expected a non-empty string value for '{_GITHUB_RELEASE_TAG_ENV_VAR}' environment variable"
-    assert "project" in pyproject_toml_data.keys(), f"Missing expected top-level 'project' key in pyproject.toml file."
+    assert github_release_tag is not None, (
+        f"Expected a non-empty string value for '{_GITHUB_RELEASE_TAG_ENV_VAR}' environment variable, but got None."
+    )
+    assert len(github_release_tag) > 0, (
+        f"Expected a non-empty string value for '{_GITHUB_RELEASE_TAG_ENV_VAR}' environment variable"
+    )
+    assert "project" in pyproject_toml_data, "Missing expected top-level 'project' key in pyproject.toml file."
     project_data = pyproject_toml_data["project"]
-    assert "version" in project_data, f"Missing expected 'version' key in the 'project' section of pyproject.toml file."
+    assert "version" in project_data, "Missing expected 'version' key in the 'project' section of pyproject.toml file."
     pyproject_version_id = project_data["version"]
     github_release_semver = github_release_tag.removeprefix("v")
-    assert (
-        pyproject_version_id == github_release_semver
-    ), f"Version mismatch detected between pyproject.toml value ({pyproject_version_id}) and GitHub release tag semver ({github_release_semver}). Did you forget to update the version in pyproject.toml?"
+    assert pyproject_version_id == github_release_semver, (
+        f"Version mismatch detected between pyproject.toml value ({pyproject_version_id}) and GitHub release tag semver ({github_release_semver}). Did you forget to update the version in pyproject.toml?"
+    )

--- a/tests/run_cache_tests/test_run_cache.py
+++ b/tests/run_cache_tests/test_run_cache.py
@@ -1,17 +1,13 @@
+from collections.abc import Callable
 from datetime import datetime
-from typing import Any, Callable
+from typing import Any
 from unittest.mock import MagicMock, call, patch
 
 import pytest
 
 from plastered.config.config_parser import AppConfig
-from plastered.run_cache.run_cache import (
-    CacheType,
-    RunCache,
-    _tomorrow_midnight_datetime,
-)
-from plastered.utils.exceptions import RunCacheDisabledException, RunCacheException
-from tests.conftest import api_run_cache, scraper_run_cache, valid_app_config
+from plastered.run_cache.run_cache import CacheType, RunCache, _tomorrow_midnight_datetime
+from plastered.utils.exceptions import RunCacheDisabledException
 
 _DT_STR_FORMAT = "%Y-%m-%d %H:%M:%S"
 
@@ -60,18 +56,9 @@ def test_tomorrow_midnight_datetime(function_invoked_datetime: datetime, expecte
 
 @pytest.mark.parametrize(
     "enabled, cache_type",
-    [
-        (False, CacheType.API),
-        (True, CacheType.API),
-        (False, CacheType.SCRAPER),
-        (True, CacheType.SCRAPER),
-    ],
+    [(False, CacheType.API), (True, CacheType.API), (False, CacheType.SCRAPER), (True, CacheType.SCRAPER)],
 )
-def test_run_cache_init(
-    valid_app_config: AppConfig,
-    enabled: bool,
-    cache_type: CacheType,
-) -> None:
+def test_run_cache_init(valid_app_config: AppConfig, enabled: bool, cache_type: CacheType) -> None:
     with patch.object(AppConfig, "is_cache_enabled") as mock_app_conf_is_cache_enabled:
         with patch("plastered.run_cache.run_cache.Cache") as mock_diskcache:
             mock_app_conf_is_cache_enabled.return_value = enabled
@@ -81,9 +68,9 @@ def test_run_cache_init(
             else:
                 mock_diskcache.assert_not_called()
             actual_enabled_attr = run_cache.enabled
-            assert (
-                actual_enabled_attr == enabled
-            ), f"Expected run_cach.enabled to be {enabled}, but got {actual_enabled_attr}"
+            assert actual_enabled_attr == enabled, (
+                f"Expected run_cach.enabled to be {enabled}, but got {actual_enabled_attr}"
+            )
 
 
 @pytest.mark.parametrize(
@@ -229,16 +216,10 @@ def test_seconds_to_expiry(
 
 @pytest.mark.parametrize(
     "cache_type, test_key, test_data",
-    [
-        (CacheType.API, "my-fake-key", "my-fake-value"),
-        (CacheType.SCRAPER, "my-fake-key", "my-fake-value"),
-    ],
+    [(CacheType.API, "my-fake-key", "my-fake-value"), (CacheType.SCRAPER, "my-fake-key", "my-fake-value")],
 )
 def test_run_cache_write_data_valid(
-    valid_app_config: AppConfig,
-    cache_type: CacheType,
-    test_key: Any,
-    test_data: Any,
+    valid_app_config: AppConfig, cache_type: CacheType, test_key: Any, test_data: Any
 ) -> None:
     mock_diskcache = MagicMock()
     with patch.object(AppConfig, "is_cache_enabled") as mock_app_conf_cache_enabled:
@@ -258,16 +239,10 @@ def test_run_cache_write_data_valid(
 
 @pytest.mark.parametrize(
     "cache_type, test_key, test_data",
-    [
-        (CacheType.API, "my-fake-key", "my-fake-value"),
-        (CacheType.SCRAPER, "my-fake-key", "my-fake-value"),
-    ],
+    [(CacheType.API, "my-fake-key", "my-fake-value"), (CacheType.SCRAPER, "my-fake-key", "my-fake-value")],
 )
 def test_run_cache_write_data_invalid(
-    valid_app_config: AppConfig,
-    cache_type: CacheType,
-    test_key: Any,
-    test_data: Any,
+    valid_app_config: AppConfig, cache_type: CacheType, test_key: Any, test_data: Any
 ) -> None:
     mock_diskcache = MagicMock()
     with patch.object(AppConfig, "is_cache_enabled") as mock_app_conf_cache_enabled:
@@ -281,18 +256,9 @@ def test_run_cache_write_data_invalid(
 
 @pytest.mark.parametrize(
     "cache_type, run_cache_enabled",
-    [
-        (CacheType.API, False),
-        (CacheType.SCRAPER, False),
-        (CacheType.API, True),
-        (CacheType.SCRAPER, True),
-    ],
+    [(CacheType.API, False), (CacheType.SCRAPER, False), (CacheType.API, True), (CacheType.SCRAPER, True)],
 )
-def test_run_cache_clear(
-    valid_app_config: AppConfig,
-    cache_type: CacheType,
-    run_cache_enabled: bool,
-) -> None:
+def test_run_cache_clear(valid_app_config: AppConfig, cache_type: CacheType, run_cache_enabled: bool) -> None:
     mock_diskcache = MagicMock()
     with patch.object(AppConfig, "is_cache_enabled") as mock_app_conf_cache_enabled:
         mock_app_conf_cache_enabled.return_value = run_cache_enabled
@@ -320,10 +286,7 @@ def test_run_cache_clear(
     ],
 )
 def test_run_cache_check(
-    valid_app_config: AppConfig,
-    cache_type: CacheType,
-    run_cache_enabled: bool,
-    should_fail: bool,
+    valid_app_config: AppConfig, cache_type: CacheType, run_cache_enabled: bool, should_fail: bool
 ) -> None:
     mock_diskcache = MagicMock()
     expected_check_result_no_fail = ["fake warning"]
@@ -348,18 +311,9 @@ def test_run_cache_check(
 
 @pytest.mark.parametrize(
     "cache_type, run_cache_enabled",
-    [
-        (CacheType.API, False),
-        (CacheType.SCRAPER, False),
-        (CacheType.API, True),
-        (CacheType.SCRAPER, True),
-    ],
+    [(CacheType.API, False), (CacheType.SCRAPER, False), (CacheType.API, True), (CacheType.SCRAPER, True)],
 )
-def test_print_summary_info(
-    valid_app_config: AppConfig,
-    cache_type: CacheType,
-    run_cache_enabled: bool,
-) -> None:
+def test_print_summary_info(valid_app_config: AppConfig, cache_type: CacheType, run_cache_enabled: bool) -> None:
     mock_diskcache = MagicMock()
 
     def _stats_side_effect(*args, **kwargs) -> tuple[int, int] | None:

--- a/tests/scraper_tests/conftest.py
+++ b/tests/scraper_tests/conftest.py
@@ -13,21 +13,21 @@ _MOCK_TRACK_RECS_PAGE_ONE_FILEPATH = os.path.join(MOCK_HTML_RESPONSES_DIR_PATH, 
 
 @pytest.fixture(scope="session")
 def login_page_html() -> str:
-    with open(_MOCK_LOGIN_HTML_FILEPATH, "r") as f:
+    with open(_MOCK_LOGIN_HTML_FILEPATH) as f:
         html = f.read()
     return html
 
 
 @pytest.fixture(scope="session")
 def album_recs_page_one_html() -> str:
-    with open(_MOCK_ALBUM_RECS_PAGE_ONE_FILEPATH, "r") as f:
+    with open(_MOCK_ALBUM_RECS_PAGE_ONE_FILEPATH) as f:
         html = f.read()
     return html
 
 
 @pytest.fixture(scope="session")
 def track_recs_page_one_html() -> str:
-    with open(_MOCK_TRACK_RECS_PAGE_ONE_FILEPATH, "r") as f:
+    with open(_MOCK_TRACK_RECS_PAGE_ONE_FILEPATH) as f:
         html = f.read()
     return html
 

--- a/tests/scraper_tests/test_lfm_recs.py
+++ b/tests/scraper_tests/test_lfm_recs.py
@@ -1,5 +1,4 @@
 from typing import Any
-from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -113,9 +112,9 @@ def test_get_human_readable_artist_str(lfm_str: str, expected: str) -> None:
         rec_context=RecContext.SIMILAR_ARTIST,
     )
     actual = test_lfm_rec.get_human_readable_artist_str()
-    assert (
-        actual == expected
-    ), f"Expected LFMRec.get_human_readable_artist_str() to return '{expected}', but got '{actual}'"
+    assert actual == expected, (
+        f"Expected LFMRec.get_human_readable_artist_str() to return '{expected}', but got '{actual}'"
+    )
 
 
 @pytest.mark.parametrize("track_origin_release, expected", [(None, "None"), ("Title", "Title")])

--- a/tests/scraper_tests/test_lfm_scraper.py
+++ b/tests/scraper_tests/test_lfm_scraper.py
@@ -6,7 +6,7 @@ import pytest
 from rebrowser_playwright.sync_api import PlaywrightContextManager
 
 from plastered.config.config_parser import AppConfig
-from plastered.run_cache.run_cache import CacheType, RunCache
+from plastered.run_cache.run_cache import RunCache
 from plastered.scraper.lfm_scraper import (
     LFMRec,
     LFMRecsScraper,
@@ -26,12 +26,6 @@ from plastered.utils.constants import (
     RENDER_WAIT_SEC_MAX,
     RENDER_WAIT_SEC_MIN,
     TRACK_RECS_BASE_URL,
-)
-from tests.conftest import valid_app_config
-from tests.scraper_tests.conftest import (
-    album_recs_page_one_html,
-    login_page_html,
-    track_recs_page_one_html,
 )
 
 
@@ -294,15 +288,15 @@ def expected_track_recs(expected_album_recs: list[LFMRec]) -> list[LFMRec]:
 
 
 def test_sleep_random() -> None:
-    assert (
-        RENDER_WAIT_SEC_MIN > 0
-    ), f"Expected constant 'RENDER_WAIT_SEC_MIN' to be greater than 0, but found it set to {RENDER_WAIT_SEC_MIN}"
-    assert (
-        RENDER_WAIT_SEC_MIN < RENDER_WAIT_SEC_MAX
-    ), f"Expected constant 'RENDER_WAIT_SEC_MIN' to be less than constant 'RENDER_WAIT_SEC_MAX', but found {RENDER_WAIT_SEC_MIN} vs. {RENDER_WAIT_SEC_MAX}"
-    assert (
-        RENDER_WAIT_SEC_MAX < 10
-    ), f"Expected constant 'RENDER_WAIT_SEC_MAX' to be less than 10, but found it set to {RENDER_WAIT_SEC_MAX}"
+    assert RENDER_WAIT_SEC_MIN > 0, (
+        f"Expected constant 'RENDER_WAIT_SEC_MIN' to be greater than 0, but found it set to {RENDER_WAIT_SEC_MIN}"
+    )
+    assert RENDER_WAIT_SEC_MIN < RENDER_WAIT_SEC_MAX, (
+        f"Expected constant 'RENDER_WAIT_SEC_MIN' to be less than constant 'RENDER_WAIT_SEC_MAX', but found {RENDER_WAIT_SEC_MIN} vs. {RENDER_WAIT_SEC_MAX}"
+    )
+    assert RENDER_WAIT_SEC_MAX < 10, (
+        f"Expected constant 'RENDER_WAIT_SEC_MAX' to be less than 10, but found it set to {RENDER_WAIT_SEC_MAX}"
+    )
     with patch("plastered.scraper.lfm_scraper.randint") as mock_randint:
         mock_randint.return_value = 5
         with patch("plastered.scraper.lfm_scraper.sleep") as mock_sleep:
@@ -339,7 +333,7 @@ def test_sleep_random() -> None:
                     lfm_entity_str="Lying+%2F+A+Wooden+Box",
                     recommendation_type=RecommendationType.ALBUM,
                     rec_context=RecContext.IN_LIBRARY,
-                ),
+                )
             ],
             True,
         ),
@@ -362,10 +356,7 @@ def test_sleep_random() -> None:
         ),
     ],
 )
-def test_cached_album_recs_validator(
-    cached_data: Any,
-    expected: bool,
-) -> None:
+def test_cached_album_recs_validator(cached_data: Any, expected: bool) -> None:
     actual = cached_lfm_recs_validator(cached_data=cached_data)
     assert actual == expected, f"Expected {expected}, but got {actual}"
 
@@ -377,19 +368,19 @@ def test_scraper_init(lfm_rec_scraper: LFMRecsScraper, valid_app_config: AppConf
         exit_method_mock.assert_not_called()
     expected_username = valid_app_config.get_cli_option("lfm_username")
     actual_username = lfm_rec_scraper._lfm_username
-    assert (
-        actual_username == expected_username
-    ), f"Unexpected username in LFMRecsScraper instance: '{actual_username}'. Expected: '{expected_username}'"
+    assert actual_username == expected_username, (
+        f"Unexpected username in LFMRecsScraper instance: '{actual_username}'. Expected: '{expected_username}'"
+    )
     expected_password = valid_app_config.get_cli_option("lfm_password")
     actual_password = lfm_rec_scraper._lfm_password
-    assert (
-        actual_password == expected_password
-    ), f"Unexpected password in LFMRecsScraper instance: '{actual_password}'. Expected: '{expected_password}'"
+    assert actual_password == expected_password, (
+        f"Unexpected password in LFMRecsScraper instance: '{actual_password}'. Expected: '{expected_password}'"
+    )
     expected_is_logged_in = False
     actual_is_logged_in = lfm_rec_scraper._is_logged_in
-    assert (
-        actual_is_logged_in == expected_is_logged_in
-    ), f"Expected LFMRecsScraper instance's _is_logged_in field to be False up __init__ call, but was {actual_is_logged_in}"
+    assert actual_is_logged_in == expected_is_logged_in, (
+        f"Expected LFMRecsScraper instance's _is_logged_in field to be False up __init__ call, but was {actual_is_logged_in}"
+    )
 
 
 def test_scraper_enter_no_cache(lfm_rec_scraper: LFMRecsScraper) -> None:
@@ -499,9 +490,9 @@ def test_user_login(lfm_rec_scraper: LFMRecsScraper) -> None:
                 call.locator().click(),
             ]
         )
-        assert (
-            lfm_rec_scraper._is_logged_in
-        ), f"Expected lfm_rec_scraper._is_logged_in to be True after calling _user_login()."
+        assert lfm_rec_scraper._is_logged_in, (
+            "Expected lfm_rec_scraper._is_logged_in to be True after calling _user_login()."
+        )
         mock_sleep_random.assert_called_once()
 
 
@@ -516,9 +507,9 @@ def test_user_logout(lfm_rec_scraper: LFMRecsScraper) -> None:
             call.get_by_role().locator().first.click(),
         ]
     )
-    assert (
-        not lfm_rec_scraper._is_logged_in
-    ), f"Expected lfm_rec_scraper._is_logged_in to be False after calling _user_logout()."
+    assert not lfm_rec_scraper._is_logged_in, (
+        "Expected lfm_rec_scraper._is_logged_in to be False after calling _user_logout()."
+    )
 
 
 @pytest.mark.parametrize("rec_type", [(RecommendationType.ALBUM), (RecommendationType.TRACK)])
@@ -536,20 +527,17 @@ def test_extract_recs_from_page_source(
     else:
         mock_page_source = track_recs_page_one_html
         expected_recs = expected_track_recs
-    actual_recs_list = lfm_rec_scraper._extract_recs_from_page_source(
-        page_source=mock_page_source,
-        rec_type=rec_type,
-    )
+    actual_recs_list = lfm_rec_scraper._extract_recs_from_page_source(page_source=mock_page_source, rec_type=rec_type)
     expected_length = len(expected_recs)
     actual_length = len(actual_recs_list)
-    assert (
-        actual_length == expected_length
-    ), f"Expected {expected_length} {rec_type.value} recs, but got {actual_length}."
+    assert actual_length == expected_length, (
+        f"Expected {expected_length} {rec_type.value} recs, but got {actual_length}."
+    )
     for i, actual_rec in enumerate(actual_recs_list):
         expected_rec = expected_recs[i]
-        assert (
-            actual_rec == expected_rec
-        ), f"Expected {i}'th {rec_type.value} rec to be '{str(expected_rec)}' but got '{str(actual_rec)}'"
+        assert actual_rec == expected_rec, (
+            f"Expected {i}'th {rec_type.value} rec to be '{str(expected_rec)}' but got '{str(actual_rec)}'"
+        )
 
 
 @pytest.mark.parametrize(
@@ -579,10 +567,7 @@ def test_navigate_to_page_and_get_page_source(
 
 @pytest.mark.parametrize(
     "rec_type, expected_rec_base_url",
-    [
-        (RecommendationType.ALBUM, ALBUM_RECS_BASE_URL),
-        (RecommendationType.TRACK, TRACK_RECS_BASE_URL),
-    ],
+    [(RecommendationType.ALBUM, ALBUM_RECS_BASE_URL), (RecommendationType.TRACK, TRACK_RECS_BASE_URL)],
 )
 def test_scrape_recs_list(
     lfm_rec_scraper: LFMRecsScraper, rec_type: RecommendationType, expected_rec_base_url: str

--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -1,10 +1,8 @@
 bandit==1.8.0
-black==24.10.0
-isort==5.13.2
-pylint==3.3.7
 pytest==8.4.0
 pytest-cov[toml]==6.1.1
 pytest-httpx==0.35.0
+ruff==0.11.13
 coverage-badge==1.1.2
 # NOTE: changing the version of mkdocs-click will require a validation that it
 # doesn't break the CLI_reference.md doc auto-generation, since that uses the library's internal API.

--- a/tests/utils_tests/httpx_utils_tests/test_httpx_utils.py
+++ b/tests/utils_tests/httpx_utils_tests/test_httpx_utils.py
@@ -6,15 +6,8 @@ import pytest
 
 from plastered.config.config_parser import AppConfig
 from plastered.run_cache.run_cache import RunCache
-from plastered.utils.constants import (
-    LFM_API_BASE_URL,
-    MUSICBRAINZ_API_BASE_URL,
-    RED_API_BASE_URL,
-)
-from plastered.utils.httpx_utils.base_client import (
-    ThrottledAPIBaseClient,
-    precise_delay,
-)
+from plastered.utils.constants import LFM_API_BASE_URL, MUSICBRAINZ_API_BASE_URL, RED_API_BASE_URL
+from plastered.utils.httpx_utils.base_client import ThrottledAPIBaseClient, precise_delay
 from plastered.utils.httpx_utils.lfm_client import LFMAPIClient
 from plastered.utils.httpx_utils.musicbrainz_client import MusicBrainzAPIClient
 from plastered.utils.httpx_utils.red_client import RedAPIClient
@@ -202,17 +195,17 @@ def test_init_throttled_api_client(
     test_instance = subclass(app_config=valid_app_config, run_cache=disabled_api_run_cache)
     assert issubclass(test_instance.__class__, ThrottledAPIBaseClient)
     actual_base_domain = test_instance._base_domain
-    assert (
-        actual_base_domain == expected_base_domain
-    ), f"Expected base domain to be '{expected_base_domain}', but got '{actual_base_domain}'"
+    assert actual_base_domain == expected_base_domain, (
+        f"Expected base domain to be '{expected_base_domain}', but got '{actual_base_domain}'"
+    )
     app_config_keys = _API_CLIENT_TO_APP_CONFIG_KEYS[test_instance.__class__.__name__]
     expected_max_retries = valid_app_config.get_cli_option(app_config_keys["retries"])
     expected_throttle_period = datetime.timedelta(seconds=valid_app_config.get_cli_option(app_config_keys["period"]))
     actual_max_retries = test_instance._max_api_call_retries
-    assert (
-        actual_max_retries == expected_max_retries
-    ), f"Expected max retries to be {expected_max_retries}, but got {actual_max_retries}"
+    assert actual_max_retries == expected_max_retries, (
+        f"Expected max retries to be {expected_max_retries}, but got {actual_max_retries}"
+    )
     actual_throttle_period = test_instance._throttle_period
-    assert (
-        actual_throttle_period == expected_throttle_period
-    ), f"Expected throttle period to be {expected_throttle_period}, but got {actual_throttle_period}"
+    assert actual_throttle_period == expected_throttle_period, (
+        f"Expected throttle period to be {expected_throttle_period}, but got {actual_throttle_period}"
+    )

--- a/tests/utils_tests/httpx_utils_tests/test_lfm_client.py
+++ b/tests/utils_tests/httpx_utils_tests/test_lfm_client.py
@@ -21,18 +21,7 @@ def expected_lfm_request_api_res_top_keys() -> dict[str, set[str]]:
             ["artist", "image", "listeners", "mbid", "name", "playcount", "tags", "tracks", "url", "wiki"]
         ),
         "track.getinfo": set(
-            [
-                "album",
-                "artist",
-                "duration",
-                "listeners",
-                "mbid",
-                "name",
-                "playcount",
-                "streamable",
-                "toptags",
-                "url",
-            ]
+            ["album", "artist", "duration", "listeners", "mbid", "name", "playcount", "streamable", "toptags", "url"]
         ),
     }
 
@@ -63,10 +52,7 @@ def test_request_lfm_api(
 @pytest.mark.override_global_httpx_mock
 @pytest.mark.parametrize("method", ["album.getinfo", "track.getinfo"])
 def test_request_lfm_api_non_200_status(
-    httpx_mock: HTTPXMock,
-    disabled_api_run_cache: RunCache,
-    valid_app_config: AppConfig,
-    method: str,
+    httpx_mock: HTTPXMock, disabled_api_run_cache: RunCache, valid_app_config: AppConfig, method: str
 ) -> None:
     httpx_mock.add_response(status_code=404)
     lfm_client = LFMAPIClient(app_config=valid_app_config, run_cache=disabled_api_run_cache)
@@ -80,10 +66,7 @@ def test_request_lfm_api_non_200_status(
 @pytest.mark.override_global_httpx_mock
 @pytest.mark.parametrize("method", ["album.getinfo", "track.getinfo"])
 def test_request_lfm_api_bad_json_response(
-    httpx_mock: HTTPXMock,
-    disabled_api_run_cache: RunCache,
-    valid_app_config: AppConfig,
-    method: str,
+    httpx_mock: HTTPXMock, disabled_api_run_cache: RunCache, valid_app_config: AppConfig, method: str
 ) -> None:
     httpx_mock.add_response(
         status_code=200, json={"error": 123, "message": "LFM API handles errors like this sometimes"}
@@ -91,7 +74,7 @@ def test_request_lfm_api_bad_json_response(
     lfm_client = LFMAPIClient(app_config=valid_app_config, run_cache=disabled_api_run_cache)
     lfm_client._throttle = Mock(name="_throttle")
     lfm_client._throttle.return_value = None
-    with pytest.raises(LFMClientException, match=f"LFM API error encounterd. LFM error code: '123'"):
+    with pytest.raises(LFMClientException, match="LFM API error encounterd. LFM error code: '123'"):
         lfm_client.request_api(method=method, params="fakekey=fakevalue")
 
 

--- a/tests/utils_tests/httpx_utils_tests/test_mb_client.py
+++ b/tests/utils_tests/httpx_utils_tests/test_mb_client.py
@@ -21,9 +21,7 @@ def mb_track_response_raise_key_error() -> dict[str, Any]:
 
 @pytest.mark.parametrize("expected_mbid", ["d211379d-3203-47ed-a0c5-e564815bb45a"])
 def test_request_musicbrainz_api(
-    valid_app_config: AppConfig,
-    disabled_api_run_cache: RunCache,
-    expected_mbid: str,
+    valid_app_config: AppConfig, disabled_api_run_cache: RunCache, expected_mbid: str
 ) -> None:
     mb_client = MusicBrainzAPIClient(app_config=valid_app_config, run_cache=disabled_api_run_cache)
     mb_client._throttle = Mock(name="_throttle")
@@ -31,11 +29,11 @@ def test_request_musicbrainz_api(
     result = mb_client.request_release_details(mbid=expected_mbid)
     mb_client._throttle.assert_called_once()
     assert isinstance(result, dict), f"Expected result from request_api to be a dict, but was: {type(result)}"
-    assert "id" in result.keys(), f"Missing expected top-level key in musicbrainz response: 'id'"
+    assert "id" in result.keys(), "Missing expected top-level key in musicbrainz response: 'id'"
     response_mbid = result["id"]
-    assert (
-        response_mbid == expected_mbid
-    ), f"Mismatch between actual response mbid ('{response_mbid}') and expected mbid ('{expected_mbid}')"
+    assert response_mbid == expected_mbid, (
+        f"Mismatch between actual response mbid ('{response_mbid}') and expected mbid ('{expected_mbid}')"
+    )
 
 
 @pytest.mark.parametrize(
@@ -58,9 +56,7 @@ def test_mb_get_track_search_query_str(
     mb_client._throttle = Mock(name="_throttle")
     mb_client._throttle.return_value = None
     actual = mb_client._get_track_search_query_str(
-        human_readable_track_name=track_name,
-        artist_mbid=artist_mbid,
-        human_readable_artist_name=artist_name,
+        human_readable_track_name=track_name, artist_mbid=artist_mbid, human_readable_artist_name=artist_name
     )
     assert actual == expected, f"Expected '{expected}', but got '{actual}'"
 
@@ -138,9 +134,7 @@ def test_request_release_details_for_track(
     mb_client._throttle = Mock(name="_throttle")
     mb_client._throttle.return_value = None
     actual = mb_client.request_release_details_for_track(
-        human_readable_track_name=track_name,
-        artist_mbid=artist_mbid,
-        human_readable_artist_name=artist_name,
+        human_readable_track_name=track_name, artist_mbid=artist_mbid, human_readable_artist_name=artist_name
     )
     assert actual == expected, f"Expected {expected}, but got {actual}"
 
@@ -172,26 +166,20 @@ def test_request_release_details_for_track_cache_hit(
 ) -> None:
     mb_client = MusicBrainzAPIClient(app_config=valid_app_config, run_cache=enabled_api_run_cache)
     query_params = mb_client._get_track_search_query_str(
-        human_readable_track_name=track_name,
-        artist_mbid=artist_mbid,
-        human_readable_artist_name=artist_name,
+        human_readable_track_name=track_name, artist_mbid=artist_mbid, human_readable_artist_name=artist_name
     )
     mb_client._throttle = Mock(name="_throttle")
     mb_client._throttle.return_value = None
     mb_client._write_cache_if_enabled(endpoint="recording", params=query_params, result_json=expected_cache_val)
     mb_client.request_release_details_for_track(
-        human_readable_track_name=track_name,
-        artist_mbid=artist_mbid,
-        human_readable_artist_name=artist_name,
+        human_readable_track_name=track_name, artist_mbid=artist_mbid, human_readable_artist_name=artist_name
     )
     mb_client._throttle.assert_not_called()
 
 
 @pytest.mark.override_global_httpx_mock
 def test_mb_client_cache_hit(
-    httpx_mock: HTTPXMock,
-    enabled_api_run_cache: RunCache,
-    valid_app_config: AppConfig,
+    httpx_mock: HTTPXMock, enabled_api_run_cache: RunCache, valid_app_config: AppConfig
 ) -> None:
     params = "fake-mbid-123"
     mocked_json = {"musicbrainz-deeznuts": {"cache_hit": "hopefully"}}

--- a/tests/utils_tests/httpx_utils_tests/test_red_client.py
+++ b/tests/utils_tests/httpx_utils_tests/test_red_client.py
@@ -71,7 +71,7 @@ def test_request_red_api(
         assert actual_throttle_call_cnt == expected_throttle_call_cnt
     if not should_fail:
         assert isinstance(result, dict), f"Expected result type to be a dict, but got: {type(result)}"
-        assert set(result.keys()) == expected_top_keys, f"Unexpected top-level JSON keys in response."
+        assert set(result.keys()) == expected_top_keys, "Unexpected top-level JSON keys in response."
 
 
 @pytest.mark.override_global_httpx_mock

--- a/tests/utils_tests/httpx_utils_tests/test_red_snatch_client.py
+++ b/tests/utils_tests/httpx_utils_tests/test_red_snatch_client.py
@@ -1,5 +1,5 @@
+from collections.abc import Callable
 from contextlib import nullcontext
-from typing import Callable
 from unittest.mock import Mock
 
 import pytest
@@ -13,12 +13,7 @@ from plastered.utils.httpx_utils.red_snatch_client import RedSnatchAPIClient
 
 @pytest.mark.parametrize(
     "initial_use_fl_tokens, initial_tokens, expected_use_fl_tokens, expected_available_fl_tokens",
-    [
-        (False, 0, False, 0),
-        (False, 1, False, 1),
-        (True, 0, False, 0),
-        (True, 1, True, 1),
-    ],
+    [(False, 0, False, 0), (False, 1, False, 1), (True, 0, False, 0), (True, 1, True, 1)],
 )
 def test_set_initial_available_fl_tokens(
     disabled_api_run_cache: RunCache,
@@ -39,10 +34,7 @@ def test_set_initial_available_fl_tokens(
 @pytest.mark.override_global_httpx_mock
 @pytest.mark.parametrize("mock_response_code", [200, 404])
 def test_snatch_red_api_no_fl(
-    httpx_mock: HTTPXMock,
-    disabled_api_run_cache: RunCache,
-    valid_app_config: AppConfig,
-    mock_response_code: int,
+    httpx_mock: HTTPXMock, disabled_api_run_cache: RunCache, valid_app_config: AppConfig, mock_response_code: int
 ) -> None:
     httpx_mock.add_response(status_code=mock_response_code)
     red_snatch_client = RedSnatchAPIClient(app_config=valid_app_config, run_cache=disabled_api_run_cache)
@@ -88,9 +80,9 @@ def test_snatch_red_api_use_token(
     for i, expected_get_url in enumerate(expected_get_urls):
         assert str(actual_requests[i].url) == expected_get_url
     actual_throttle_calls = len(red_snatch_client._throttle.mock_calls)
-    assert (
-        actual_throttle_calls == expected_throttle_calls
-    ), f"Expected {expected_throttle_calls}, but found {actual_throttle_calls}"
+    assert actual_throttle_calls == expected_throttle_calls, (
+        f"Expected {expected_throttle_calls}, but found {actual_throttle_calls}"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/utils_tests/test_cli_utils.py
+++ b/tests/utils_tests/test_cli_utils.py
@@ -7,23 +7,12 @@ import pytest
 from plastered.utils.cli_utils import StatsRunPicker
 from plastered.utils.constants import RUN_DATE_STR_FORMAT
 from plastered.utils.exceptions import StatsRunPickerException
-from tests.conftest import (
-    mock_output_summary_dir_path,
-    mock_root_summary_dir_path,
-    mock_summary_tsvs,
-    valid_app_config,
-)
 
 
 def test_init_stats_run_picker(
-    mock_root_summary_dir_path: Path,
-    mock_output_summary_dir_path: Path,
-    mock_summary_tsvs: dict[str, str],
+    mock_root_summary_dir_path: Path, mock_output_summary_dir_path: Path, mock_summary_tsvs: dict[str, str]
 ) -> None:
-    srp = StatsRunPicker(
-        summaries_directory_path=mock_root_summary_dir_path,
-        date_str_format=RUN_DATE_STR_FORMAT,
-    )
+    srp = StatsRunPicker(summaries_directory_path=mock_root_summary_dir_path, date_str_format=RUN_DATE_STR_FORMAT)
     assert len(srp._possible_datetimes) > 0
     assert srp._candidate_dt.year == 1970
     assert srp._candidate_dt.month == 1
@@ -69,10 +58,7 @@ def test_stats_run_picker_is_valid_candidate_dt(
     candidate_dt: datetime,
     expected: bool,
 ) -> None:
-    srp = StatsRunPicker(
-        summaries_directory_path=mock_root_summary_dir_path,
-        date_str_format=RUN_DATE_STR_FORMAT,
-    )
+    srp = StatsRunPicker(summaries_directory_path=mock_root_summary_dir_path, date_str_format=RUN_DATE_STR_FORMAT)
     srp._candidate_dt = candidate_dt
     actual = srp._is_valid_candidate_dt(dt=dt_arg, dt_attr_name=dt_attr_name)
     assert actual == expected
@@ -149,10 +135,7 @@ def test_stats_run_picker_get_dt_choices(
 ) -> None:
     with patch.object(StatsRunPicker, "_is_valid_candidate_dt") as mock_is_valid_candidate_dt:
         mock_is_valid_candidate_dt.return_value = True
-        srp = StatsRunPicker(
-            summaries_directory_path=mock_root_summary_dir_path,
-            date_str_format=RUN_DATE_STR_FORMAT,
-        )
+        srp = StatsRunPicker(summaries_directory_path=mock_root_summary_dir_path, date_str_format=RUN_DATE_STR_FORMAT)
         srp._possible_datetimes = mock_possible_datetimes
         actual = srp._get_dt_choices(dt_attr_name=dt_attr_name)
         assert actual == expected
@@ -187,8 +170,7 @@ def test_prompt_date_component(
                 datetime(year=2025, month=2, day=15, hour=1, minute=11, second=25),
             ]
             srp = StatsRunPicker(
-                summaries_directory_path=mock_root_summary_dir_path,
-                date_str_format=RUN_DATE_STR_FORMAT,
+                summaries_directory_path=mock_root_summary_dir_path, date_str_format=RUN_DATE_STR_FORMAT
             )
             assert (
                 srp._candidate_dt.year == 1970
@@ -239,14 +221,11 @@ def test_get_run_date_from_user_prompts(
     mock_q_ask.ask.side_effect = mock_user_inputs
     with patch("questionary.select") as questionary_select_mock:
         questionary_select_mock.return_value = mock_q_ask
-        srp = StatsRunPicker(
-            summaries_directory_path=mock_root_summary_dir_path,
-            date_str_format=RUN_DATE_STR_FORMAT,
-        )
+        srp = StatsRunPicker(summaries_directory_path=mock_root_summary_dir_path, date_str_format=RUN_DATE_STR_FORMAT)
         srp._possible_datetimes = mock_possible_datetimes
         actual = srp.get_run_date_from_user_prompts()
         assert actual == expected
         actual_prompt_cnt = len(questionary_select_mock.call_args_list)
-        assert (
-            actual_prompt_cnt == expected_prompt_cnt
-        ), f"Expected {expected_prompt_cnt}, but found {actual_prompt_cnt}: {questionary_select_mock.mock_calls}"
+        assert actual_prompt_cnt == expected_prompt_cnt, (
+            f"Expected {expected_prompt_cnt}, but found {actual_prompt_cnt}: {questionary_select_mock.mock_calls}"
+        )

--- a/tests/utils_tests/test_lfm_utils.py
+++ b/tests/utils_tests/test_lfm_utils.py
@@ -7,7 +7,6 @@ from plastered.scraper.lfm_scraper import LFMRec
 from plastered.scraper.lfm_scraper import RecContext as rc
 from plastered.scraper.lfm_scraper import RecommendationType as rt
 from plastered.utils.lfm_utils import LFMAlbumInfo, LFMTrackInfo
-from tests.conftest import mock_lfm_album_info_json
 
 
 def test_construct_from_api_response(mock_lfm_album_info_json: dict[str, Any]) -> None:
@@ -18,9 +17,9 @@ def test_construct_from_api_response(mock_lfm_album_info_json: dict[str, Any]) -
         lfm_url="https://www.last.fm/music/Dr.+Octagon/Dr.+Octagonecologyst",
     )
     actual_lfmai = LFMAlbumInfo.construct_from_api_response(json_blob=mock_lfm_album_info_json["album"])
-    assert (
-        actual_lfmai == expected_lfmai
-    ), f"Expected LFMAlbumInfo to be '{str(expected_lfmai)}', but got '{str(actual_lfmai)}'"
+    assert actual_lfmai == expected_lfmai, (
+        f"Expected LFMAlbumInfo to be '{str(expected_lfmai)}', but got '{str(actual_lfmai)}'"
+    )
 
 
 @pytest.mark.parametrize(
@@ -74,9 +73,7 @@ def test_construct_from_api_response(mock_lfm_album_info_json: dict[str, Any]) -
     ],
 )
 def test_lfmti_from_mb_origin_release_info(
-    si: SearchItem,
-    mb_origin_release_info_json: dict[str, Any],
-    expected_lfmti: LFMTrackInfo | None,
+    si: SearchItem, mb_origin_release_info_json: dict[str, Any], expected_lfmti: LFMTrackInfo | None
 ) -> None:
     actual = LFMTrackInfo.from_mb_origin_release_info(si=si, mb_origin_release_info_json=mb_origin_release_info_json)
     assert actual == expected_lfmti

--- a/tests/utils_tests/test_musicbrainz_utils.py
+++ b/tests/utils_tests/test_musicbrainz_utils.py
@@ -5,7 +5,6 @@ import pytest
 
 from plastered.utils.musicbrainz_utils import MBRelease
 from plastered.utils.red_utils import RedReleaseType
-from tests.conftest import mock_musicbrainz_release_json
 
 
 @pytest.mark.parametrize(
@@ -58,17 +57,14 @@ def test_eq(other: Any, expected: bool) -> None:
     assert actual == expected, f"Expected {test_instance}.__eq__(other={other}) to be {expected}, but got {actual}"
 
 
-def test_construct_from_api(
-    mock_musicbrainz_release_json: dict[str, Any],
-    expected_mb_release: MBRelease,
-) -> None:
+def test_construct_from_api(mock_musicbrainz_release_json: dict[str, Any], expected_mb_release: MBRelease) -> None:
     actual = MBRelease.construct_from_api(json_blob=mock_musicbrainz_release_json)
     assert actual == expected_mb_release
     expected_red_release_type = RedReleaseType.ALBUM
     actual_red_release_type = actual.get_red_release_type()
-    assert (
-        actual_red_release_type == expected_red_release_type
-    ), f"Expected red release type set to '{expected_red_release_type}' but got '{actual_red_release_type}' instead."
+    assert actual_red_release_type == expected_red_release_type, (
+        f"Expected red release type set to '{expected_red_release_type}' but got '{actual_red_release_type}' instead."
+    )
     expected_first_release_year = 1996
     actual_first_release_year = actual.get_first_release_year()
     assert actual_first_release_year == expected_first_release_year
@@ -80,30 +76,21 @@ def test_construct_from_api(
     assert actual_catalog_number == expected_catalog_number
     expected_release_url = "https://musicbrainz.org/release/d211379d-3203-47ed-a0c5-e564815bb45a"
     actual_release_url = actual.get_musicbrainz_release_url()
-    assert (
-        actual_release_url == expected_release_url
-    ), f"Unexpected mb release url: '{actual_release_url}'. Expected: '{expected_release_url}'"
+    assert actual_release_url == expected_release_url, (
+        f"Unexpected mb release url: '{actual_release_url}'. Expected: '{expected_release_url}'"
+    )
     expected_release_group_url = "https://musicbrainz.org/release-group/b38e21f6-8f76-3f87-a021-e91afad9e7e5"
     actual_release_group_url = actual.get_musicbrainz_release_group_url()
-    assert (
-        actual_release_group_url == expected_release_group_url
-    ), f"Unexpected mb release group url: '{actual_release_group_url}'. Expected: '{expected_release_group_url}'"
+    assert actual_release_group_url == expected_release_group_url, (
+        f"Unexpected mb release group url: '{actual_release_group_url}'. Expected: '{expected_release_group_url}'"
+    )
 
 
 @pytest.mark.parametrize(
     "raw_field_present, raw_field_value, expected_year",
-    [
-        (False, "", -1),
-        (True, "2017-10-19", 2017),
-        (True, "2009", 2009),
-        (True, "1995-12", 1995),
-    ],
+    [(False, "", -1), (True, "2017-10-19", 2017), (True, "2009", 2009), (True, "1995-12", 1995)],
 )
-def test_release_year_non_match(
-    raw_field_present: bool,
-    raw_field_value: str,
-    expected_year: int,
-) -> None:
+def test_release_year_non_match(raw_field_present: bool, raw_field_value: str, expected_year: int) -> None:
     release_group_json = {"primary-type": "Single", "id": "fake-rg-mbid"}
     if raw_field_present:
         release_group_json["first-release-date"] = raw_field_value
@@ -118,9 +105,9 @@ def test_release_year_non_match(
         }
     )
     actual_release_year = mbr.get_first_release_year()
-    assert (
-        actual_release_year == expected_year
-    ), f"Expected first_release_year of {expected_year}, but got {actual_release_year} instead."
+    assert actual_release_year == expected_year, (
+        f"Expected first_release_year of {expected_year}, but got {actual_release_year} instead."
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/utils_tests/test_red_utils.py
+++ b/tests/utils_tests/test_red_utils.py
@@ -2,7 +2,6 @@ from typing import Any
 
 import pytest
 
-from plastered.utils.constants import STORAGE_UNIT_IDENTIFIERS
 from plastered.utils.red_utils import (
     EncodingEnum,
     FormatEnum,
@@ -13,12 +12,6 @@ from plastered.utils.red_utils import (
     ReleaseEntry,
     TorrentEntry,
     _red_release_type_str_to_enum,
-)
-from tests.conftest import (
-    expected_red_format_list,
-    mock_red_browse_empty_response,
-    mock_red_browse_non_empty_response,
-    mock_red_group_response,
 )
 
 
@@ -112,9 +105,9 @@ def test_red_release_type_str_to_enum(release_type_str: str, expected: RedReleas
 )
 def test_torrent_entry_cd_only_extras_constructor(te: TorrentEntry, expected_cd_only_extras: str) -> None:
     actual_cd_only_extras = te.red_format._cd_only_extras
-    assert (
-        actual_cd_only_extras == expected_cd_only_extras
-    ), f"Expected cd_only_extras to be '{expected_cd_only_extras}', but got '{actual_cd_only_extras}'"
+    assert actual_cd_only_extras == expected_cd_only_extras, (
+        f"Expected cd_only_extras to be '{expected_cd_only_extras}', but got '{actual_cd_only_extras}'"
+    )
 
 
 @pytest.mark.parametrize(
@@ -195,11 +188,7 @@ def test_eq(other: Any, expected: bool) -> None:
     ],
 )
 def test_torrent_entry_get_size(
-    unit: str,
-    expected: float | None,
-    should_fail: bool,
-    exception: Exception | None,
-    exception_msg: str | None,
+    unit: str, expected: float | None, should_fail: bool, exception: Exception | None, exception_msg: str | None
 ) -> None:
     mock_size_bytes = 3000000.0
     test_instance = TorrentEntry(
@@ -246,15 +235,12 @@ def test_torrent_entry_get_red_format() -> None:
         lossy_master=None,
     )
     expected_red_format = RedFormat(
-        format=FormatEnum.FLAC,
-        encoding=EncodingEnum.LOSSLESS,
-        media=MediaEnum.CD,
-        cd_only_extras="haslog=100&hascue=1",
+        format=FormatEnum.FLAC, encoding=EncodingEnum.LOSSLESS, media=MediaEnum.CD, cd_only_extras="haslog=100&hascue=1"
     )
     actual_red_format = test_instance.red_format
-    assert (
-        actual_red_format == expected_red_format
-    ), f"Expected test_instance.get_red_format() to be '{str(expected_red_format)}', but got '{str(actual_red_format)}'"
+    assert actual_red_format == expected_red_format, (
+        f"Expected test_instance.get_red_format() to be '{str(expected_red_format)}', but got '{str(actual_red_format)}'"
+    )
 
 
 def test_release_entry_get_red_formats(mock_red_group_response: dict[str, Any]) -> None:
@@ -296,9 +282,9 @@ def test_release_entry_get_red_formats(mock_red_group_response: dict[str, Any]) 
         )
     ]
     actual_red_format_list = test_release_entry.get_red_formats()
-    assert (
-        actual_red_format_list == expected_red_format_list
-    ), f"Expected test_release_entry.get_red_formats() to return {expected_red_format_list}, but got {actual_red_format_list}"
+    assert actual_red_format_list == expected_red_format_list, (
+        f"Expected test_release_entry.get_red_formats() to return {expected_red_format_list}, but got {actual_red_format_list}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -375,18 +361,10 @@ def test_red_user_details_has_snatched_release(
 
 @pytest.mark.parametrize(
     "mock_snatched_tids, tid, expected",
-    [
-        ({}, 69, False),
-        ({69}, 69, True),
-        ({100, 69}, 69, True),
-        ({100, 200, 300}, 5, False),
-    ],
+    [({}, 69, False), ({69}, 69, True), ({100, 69}, 69, True), ({100, 200, 300}, 5, False)],
 )
 def test_red_user_details_has_snatched_tid(
-    mock_red_user_details_fn_scoped: RedUserDetails,
-    mock_snatched_tids: set[int],
-    tid: int,
-    expected: bool,
+    mock_red_user_details_fn_scoped: RedUserDetails, mock_snatched_tids: set[int], tid: int, expected: bool
 ) -> None:
     mock_red_user_details_fn_scoped._snatched_tids = mock_snatched_tids
     actual = mock_red_user_details_fn_scoped.has_snatched_tid(tid)


### PR DESCRIPTION
## What?
* Replaces various code linter and auto-formatter tools with [`ruff`](https://docs.astral.sh/ruff/).
* Updates the settings in `dependabot.yml` for less frequent automated version upgrade PRs.

## Why?
* Speed up linting + autoformatting, and consolidate settings into a single tool.
* Reduce dependabot PR noise, and GitHub actions month usage limits.

## Pre-merge Checklist
- [x] validated that local builds and tests passed with `make docker-test`
- [x] ensured that the changes do not violate any relevant API rate limits
- [x] any relevant documentation is updated to reflect the given changes
