### PR TITLE
Fix dependabot.yml typos and add vscode error check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,5 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
+# yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
+# for info on above comment: https://github.com/dependabot/dependabot-core/issues/4605#issuecomment-2435660718
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
@@ -11,8 +10,8 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 2
     groups:  # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates
-      app-dependencies:
-        depedency-type: "app"
+      production-dependencies:
+        dependency-type: "production"
         applies-to: version-updates
         exclude-patterns:
           - "bandit"
@@ -20,10 +19,10 @@ updates:
           - "ruff"
           - "coverage-badge"
           - "mkdocs-click"
-      test-dependencies:
-        dependency-type: "test"
+      development-dependencies:
+        dependency-type: "development"
         applies-to: version-updates
-        pattern:
+        patterns:
           - "bandit"
           - "pytest*"
           - "ruff"


### PR DESCRIPTION
## What?
* Fixes typos in dependabot config file
* Adds an inline comment to enable vscode yaml error detection

## Why?
* Prior PR ( #66 ) failed, and the error was not caught until merge since GH actions only validates the dependabot file on `main` builds
* To have sanity checks on dependabot config file validity before pushing.

## Pre-merge Checklist
- [x] validated that local builds and tests passed with `make docker-test`
- [x] ensured that the changes do not violate any relevant API rate limits
- [x] any relevant documentation is updated to reflect the given changes
