### PR TITLE
prepare for 0.2.2 release

### DIFF
--- a/docs/CLI_reference.md
+++ b/docs/CLI_reference.md
@@ -1,4 +1,4 @@
-# `plastered` CLI Reference (v0.2.1)
+# `plastered` CLI Reference (v0.2.2)
 
 > NOTE: this doc is auto-generated from the CLI source code. For a more thorough version of this information, run `plastered --help`, as outlined in the user guide.
 plastered: Finds your LFM recs and snatches them from RED.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plastered"
-version = "0.2.1"
+version = "0.2.2"
 requires-python = ">= 3.12"
 dependencies = [
     "beautifulsoup4==4.13.4",

--- a/uv.lock
+++ b/uv.lock
@@ -346,7 +346,7 @@ wheels = [
 
 [[package]]
 name = "plastered"
-version = "0.2.1"
+version = "0.2.2"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## What?
* prepares the bump to `0.2.2` 

## Why?
* Cut a patch release with the following improvements and bug fixes:
    * https://github.com/windexvalence/plastered/pull/74
    * https://github.com/windexvalence/plastered/pull/75
    * https://github.com/windexvalence/plastered/pull/77

## Pre-merge Checklist
- [x] validated that local builds and tests passed with `make docker-test`
- [x] ensured that the changes do not violate any relevant API rate limits
- [x] any relevant documentation is updated to reflect the given changes
