### PR TITLE
fix: Bump various dependency lower-bound constraints per dependabot alerts.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,13 @@ dependencies = [
 	"jsonschema==4.26.0",
 	"pydantic==2.13.4",
 	"pydantic-settings>=2.14.2",
+	"python-multipart>=0.0.31",
 	"PyYAML==6.0.3",
 	"rebrowser-playwright==1.52.0",
 	"rich==15.0.0",
+	"soupsieve>=2.8.4",
 	"sqlmodel==0.0.39",
+	"starlette>=1.3.1",
 	"tenacity==9.1.4",
 	"urllib3==2.7.0",
 ]
@@ -61,12 +64,6 @@ include = ["plastered*"]
 # both would be dropped from the wheel without this.
 [tool.setuptools.package-data]
 plastered = ["api/static/**/*", "api/templates/**/*.html", "config/*.yaml", "release_search/*.md"]
-
-# UV
-[tool.uv]
-constraint-dependencies = [
-	"soupsieve>=2.8.4",
-]
 
 [tool.ruff]
 exclude = [

--- a/uv.lock
+++ b/uv.lock
@@ -2,9 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 
-[manifest]
-constraints = [{ name = "soupsieve", specifier = ">=2.8.4" }]
-
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
@@ -895,10 +892,13 @@ dependencies = [
     { name = "jsonschema" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "rebrowser-playwright" },
     { name = "rich" },
+    { name = "soupsieve" },
     { name = "sqlmodel" },
+    { name = "starlette" },
     { name = "tenacity" },
     { name = "urllib3" },
 ]
@@ -934,10 +934,13 @@ requires-dist = [
     { name = "jsonschema", specifier = "==4.26.0" },
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
+    { name = "python-multipart", specifier = ">=0.0.31" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "rebrowser-playwright", specifier = "==1.52.0" },
     { name = "rich", specifier = "==15.0.0" },
+    { name = "soupsieve", specifier = ">=2.8.4" },
     { name = "sqlmodel", specifier = "==0.0.39" },
+    { name = "starlette", specifier = ">=1.3.1" },
     { name = "tenacity", specifier = "==9.1.4" },
     { name = "urllib3", specifier = "==2.7.0" },
 ]
@@ -1234,11 +1237,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.20"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]
@@ -1566,15 +1569,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.47.3"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/b9/cc3017f9a9c9b6e27c5106cc10cc7904653c3eec0729793aec10479dd669/starlette-0.47.3.tar.gz", hash = "sha256:6bc94f839cc176c4858894f1f8908f0ab79dfec1a6b8402f6da9be26ebea52e9", size = 2584144, upload-time = "2025-08-24T13:36:42.122Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/fd/901cfa59aaa5b30a99e16876f11abe38b59a1a2c51ffb3d7142bb6089069/starlette-0.47.3-py3-none-any.whl", hash = "sha256:89c0778ca62a76b826101e7c709e70680a1699ca7da6b44d38eb0a7e61fe4b51", size = 72991, upload-time = "2025-08-24T13:36:40.887Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What?
* Addresses several dependency vulnerability notifications but adding or increasing the minimum supported version for the following dependencies:
    * `python-multipart`
    * `soupsieve`
    * `starlette`

## Why?
* Maintain good security posture.

## Pre-merge Checklist
- [x] validated that local builds and tests passed with `make docker-test`
- [x] ensured that the changes do not violate any relevant API rate limits
- [x] any relevant documentation is updated to reflect the given changes
