### PR TITLE
feat: Migrate from `httpx` clients to `httpx2` clients

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,4 +29,7 @@ repos:
         name: mypy
         entry: hooks/mypy.sh
         language: script
-        files: '^(plastered/.*\.py|tests/.*\.py)$'
+        # plastered/ only: tests are excluded from type-checking (see [tool.mypy] in pyproject.toml), but
+        # mypy's `exclude` config does not apply to files passed explicitly as CLI args, so the hook must
+        # not pass them.
+        files: '^plastered/.*\.py$'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ All workflows go through the `Makefile` and `uv` (Python 3.12). Run `make` for t
 ### Test details
 
 - Test runner config lives in `pyproject.toml` `[tool.pytest.ini_options]`. Coverage `fail_under = 100` — **new code must be fully covered** or use the documented `pragma: no cover` / `exclude_also` patterns already in the codebase.
-- Sockets are disabled in tests (`--disable-socket`); HTTP is mocked via `pytest-httpx`. Tests run in parallel with `pytest -n auto --dist=loadfile`.
+- Sockets are disabled in tests (`--disable-socket`); HTTP is mocked via `pytest-httpx2` (respx). Tests run in parallel with `pytest -n auto --dist=loadfile`.
 - Markers gate optional suites: `slow` (run in CI or with `--slowtests`), `releasetest` (release builds only, `--releasetests`). See also `no_autouse_mock_lifespan_singleton_inst` and `override_global_httpx_mock` for opting out of autouse fixtures.
 - `tests/conftest.py` sets `PLASTERED_CONFIG` to `examples/config.yaml` before any imports — config loads eagerly at import time, so import order matters.
 
@@ -31,7 +31,7 @@ All workflows go through the `Makefile` and `uv` (Python 3.12). Run `make` for t
 
 1. The server (a scraper-page submission or `POST /api/scrape`) builds an `AppSettings` via `get_app_settings()` (merging `config.yaml` + env vars `PLASTERED_*`) and calls `scrape_action` / `run_lfm_scraper` (`plastered/actions/common_actions.py`).
 2. `LFMRecsScraper` (`plastered/scraper/lfm_scraper.py`) uses Playwright (rebrowser-playwright) to scrape recommendation pages into `dict[EntityType, list[LFMRec]]`.
-3. `ReleaseSearcher` (`plastered/release_search/release_searcher.py`) is the orchestrator. It owns four httpx API clients (LFM, MusicBrainz, RED, RED-snatch) and builds a per-run `SearchState`. It wraps each `LFMRec` in a `SearchItem` and runs them through the processor chain, then snatches matches.
+3. `ReleaseSearcher` (`plastered/release_search/release_searcher.py`) is the orchestrator. It owns four httpx2 API clients (LFM, MusicBrainz, RED, RED-snatch) and builds a per-run `SearchState`. It wraps each `LFMRec` in a `SearchItem` and runs them through the processor chain, then snatches matches.
 
 ### The processor chain (core of release_search)
 
@@ -51,9 +51,9 @@ When adding/reordering search logic, edit the chain tuples in `chains.py` and ad
 
 `AppSettings` is a pydantic-settings `BaseSettings` composed of frozen pydantic sub-models (`SearchConfig`, `SnatchesConfig`, `FormatPreference`, etc.). Sources merge in this precedence: env (`PLASTERED_*`) > YAML. The config doc at `docs/config_reference.md` is **auto-generated** from these models — after changing config fields, regenerate via `make render-config-doc`.
 
-### API clients (`plastered/utils/httpx_utils/`)
+### API clients (`plastered/utils/http_clients/`)
 
-All clients subclass `ThrottledAPIBaseClient` (`base_client.py`), which wraps `httpx.Client` with a custom retry transport (`HTTPXRetryTransport`, tenacity-based) and per-API rate limiting. The API clients do **not** cache their responses. `RunCache` (diskcache, `plastered/run_cache/run_cache.py`) is used only by the LFM scraper to cache the recommendation pages it scrapes.
+All clients subclass `ThrottledAPIBaseClient` (`base_client.py`), which wraps `httpx2.Client` with a custom retry transport (`HTTPXRetryTransport`, tenacity-based) and per-API rate limiting. The API clients do **not** cache their responses. `RunCache` (diskcache, `plastered/run_cache/run_cache.py`) is used only by the LFM scraper to cache the recommendation pages it scrapes.
 
 ### Web server (`plastered/api/`)
 
@@ -68,6 +68,6 @@ SQLModel over SQLite. `SearchRecord` is the main results table; status/skip/fail
 - **`from __future__ import annotations`** and heavy use of `TYPE_CHECKING` import blocks — ruff's `flake8-type-checking` (`TC`) rules are enforced; keep runtime-only imports out of `TYPE_CHECKING`.
 - ruff line length is 120; `E501`/`E203` are ignored (formatter handles wrapping). Tests are excluded from lint (`[tool.ruff.lint] exclude`).
 - Raising bare `Exception` is banned (`TRY002`); use the typed exceptions in `plastered/utils/exceptions.py`.
-- Domain models are re-exported from `plastered/models/__init__.py` and clients from `plastered/utils/httpx_utils/__init__.py` — import from the package, not the submodule.
+- Domain models are re-exported from `plastered/models/__init__.py` and clients from `plastered/utils/http_clients/__init__.py` — import from the package, not the submodule.
 - `mypy` runs with the pydantic plugin; tests and `build_scripts` are excluded from type-checking.
 - **Prefer `anyio` over `asyncio`.** FastAPI/Starlette run on anyio, so avoid the `asyncio` stdlib module (event loop, `asyncio.Lock`/`sleep`/`create_task`, etc.) whenever an anyio equivalent fits — e.g. offload blocking sync work with `starlette.concurrency.run_in_threadpool` (anyio's `to_thread`), use `anyio` sync primitives in async code, and use plain `threading` primitives only for coordinating sync worker-thread code. For async tests, use `@pytest.mark.anyio` with the `anyio_backend` fixture (`tests/conftest.py`), not `pytest-asyncio`.

--- a/plastered/api/lifespan_resources.py
+++ b/plastered/api/lifespan_resources.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Self
 
 from plastered.config.app_settings import get_app_settings
 from plastered.release_search.release_searcher import ReleaseSearcher
-from plastered.utils.httpx_utils import LFMAPIClient, MusicBrainzAPIClient, RedAPIClient, RedSnatchAPIClient
+from plastered.utils.http_clients import LFMAPIClient, MusicBrainzAPIClient, RedAPIClient, RedSnatchAPIClient
 from plastered.version import get_project_version
 
 if TYPE_CHECKING:

--- a/plastered/release_search/processors/bases.py
+++ b/plastered/release_search/processors/bases.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from plastered.db.db_models import SkipReason
     from plastered.models import SearchItem
     from plastered.release_search.search_helpers import SearchState
-    from plastered.utils.httpx_utils import LFMAPIClient, MusicBrainzAPIClient, RedAPIClient
+    from plastered.utils.http_clients import LFMAPIClient, MusicBrainzAPIClient, RedAPIClient
 
 
 class SearchItemModifier(ABC):

--- a/plastered/release_search/processors/chains.py
+++ b/plastered/release_search/processors/chains.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from plastered.models import SearchItem
     from plastered.release_search.processors.bases import SearchItemProcessor
     from plastered.release_search.search_helpers import SearchState
-    from plastered.utils.httpx_utils import LFMAPIClient, MusicBrainzAPIClient, RedAPIClient
+    from plastered.utils.http_clients import LFMAPIClient, MusicBrainzAPIClient, RedAPIClient
 
 
 _LOGGER = logging.getLogger(__name__)

--- a/plastered/release_search/processors/modifiers.py
+++ b/plastered/release_search/processors/modifiers.py
@@ -14,7 +14,7 @@ from plastered.utils.exceptions import LFMClientException, MusicBrainzClientExce
 if TYPE_CHECKING:
     from plastered.models import SearchItem
     from plastered.release_search.search_helpers import SearchState
-    from plastered.utils.httpx_utils import LFMAPIClient, MusicBrainzAPIClient, RedAPIClient
+    from plastered.utils.http_clients import LFMAPIClient, MusicBrainzAPIClient, RedAPIClient
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/plastered/release_search/release_searcher.py
+++ b/plastered/release_search/release_searcher.py
@@ -12,7 +12,7 @@ from plastered.release_search.processors import SearchItemProcessorChain
 from plastered.release_search.search_helpers import SearchState
 from plastered.snatch import Snatcher
 from plastered.utils.exceptions import ReleaseSearcherException
-from plastered.utils.httpx_utils import LFMAPIClient, MusicBrainzAPIClient, RedAPIClient, RedSnatchAPIClient
+from plastered.utils.http_clients import LFMAPIClient, MusicBrainzAPIClient, RedAPIClient, RedSnatchAPIClient
 from plastered.utils.log_utils import CONSOLE, SPINNER
 
 if TYPE_CHECKING:

--- a/plastered/snatch/snatcher.py
+++ b/plastered/snatch/snatcher.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from plastered.models import SearchItem
     from plastered.release_search.search_helpers import SearchState
-    from plastered.utils.httpx_utils import RedSnatchAPIClient
+    from plastered.utils.http_clients import RedSnatchAPIClient
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/plastered/utils/http_clients/__init__.py
+++ b/plastered/utils/http_clients/__init__.py
@@ -1,0 +1,6 @@
+from plastered.utils.http_clients.lfm_client import LFMAPIClient
+from plastered.utils.http_clients.musicbrainz_client import MusicBrainzAPIClient
+from plastered.utils.http_clients.red_client import RedAPIClient
+from plastered.utils.http_clients.red_snatch_client import RedSnatchAPIClient
+
+__all__ = ["LFMAPIClient", "MusicBrainzAPIClient", "RedAPIClient", "RedSnatchAPIClient"]

--- a/plastered/utils/http_clients/base_client.py
+++ b/plastered/utils/http_clients/base_client.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from time import perf_counter_ns
 from typing import Final
 
-import httpx
+import httpx2
 from tenacity import Retrying, stop_after_attempt, wait_fixed
 
 LOGGER = logging.getLogger(__name__)
@@ -23,24 +23,24 @@ def precise_delay(sec_delay: int) -> None:
         pass
 
 
-# TODO: implement, and keep in mind the differences from requests library and httpx listed in  the link below:
+# TODO: implement, and keep in mind the differences from requests library and httpx2 listed in  the link below:
 # https://www.python-httpx.org/compatibility/
 
 
-class HTTPXRetryTransport(httpx.BaseTransport):
+class HTTPXRetryTransport(httpx2.BaseTransport):
     """
-    Custom implementation of the `httpx.BaseTransport` class specifically for handling rate-limited request retries.
-    This class is used as the underlying httpx transport for all the `ThrottledAPIBaseClient` classes.
+    Custom implementation of the `httpx2.BaseTransport` class specifically for handling rate-limited request retries.
+    This class is used as the underlying httpx2 transport for all the `ThrottledAPIBaseClient` classes.
     """
 
     def __init__(self, max_retries: int, min_wait_seconds: int):
         self._max_retries = max_retries
         self._min_wait_seconds = min_wait_seconds
-        self._transport = httpx.HTTPTransport()
+        self._transport = httpx2.HTTPTransport()
 
     # NOTE: non-decorated tenacity retry logic which resets per-call to handle_request was adopted
     # from this SO answer: https://stackoverflow.com/a/62238110
-    def handle_request(self, request: httpx.Request) -> httpx.Response:
+    def handle_request(self, request: httpx2.Request) -> httpx2.Response:
         for attempt in Retrying(
             wait=wait_fixed(self._min_wait_seconds), stop=stop_after_attempt(self._max_retries), reraise=True
         ):
@@ -52,7 +52,7 @@ class HTTPXRetryTransport(httpx.BaseTransport):
 
 class ThrottledAPIBaseClient:
     """
-    Base class that wraps a distinct httpx.Client instance with retries and throttling.
+    Base class that wraps a distinct httpx2.Client instance with retries and throttling.
     Subclasses for the various rest APIs are implemented with their own request construction
     and uniquely configurable retry and throttling parameters.
     """
@@ -62,7 +62,7 @@ class ThrottledAPIBaseClient:
         base_api_url: str,
         max_api_call_retries: int,
         seconds_between_api_calls: int,
-        extra_client_transport_mount_entries: dict[str, httpx.BaseTransport] | None = None,
+        extra_client_transport_mount_entries: dict[str, httpx2.BaseTransport] | None = None,
     ):
         self._max_api_call_retries = max_api_call_retries
         self._throttle_period = timedelta(seconds=seconds_between_api_calls)
@@ -77,7 +77,7 @@ class ThrottledAPIBaseClient:
         # With the server run single-process (server.workers = 1), this makes the per-API rate limit process-global.
         self._throttle_lock = threading.Lock()
         self._base_domain = base_api_url
-        self._client = httpx.Client(
+        self._client = httpx2.Client(
             mounts={
                 self._base_domain: HTTPXRetryTransport(
                     max_retries=self._max_api_call_retries, min_wait_seconds=self._throttle_period.seconds

--- a/plastered/utils/http_clients/lfm_client.py
+++ b/plastered/utils/http_clients/lfm_client.py
@@ -4,7 +4,7 @@ from plastered.config.app_settings import AppSettings
 from plastered.release_search.search_helpers import SearchItem
 from plastered.utils.constants import LFM_API_BASE_URL
 from plastered.utils.exceptions import LFMClientException
-from plastered.utils.httpx_utils.base_client import ThrottledAPIBaseClient
+from plastered.utils.http_clients.base_client import ThrottledAPIBaseClient
 
 
 # TODO (later): refactor public `request*` methods to return Pydantic model classes.

--- a/plastered/utils/http_clients/musicbrainz_client.py
+++ b/plastered/utils/http_clients/musicbrainz_client.py
@@ -6,7 +6,7 @@ from plastered.config.app_settings import AppSettings
 from plastered.models import SearchItem
 from plastered.utils.constants import MUSICBRAINZ_API_BASE_URL
 from plastered.utils.exceptions import MusicBrainzClientException
-from plastered.utils.httpx_utils.base_client import LOGGER, ThrottledAPIBaseClient
+from plastered.utils.http_clients.base_client import LOGGER, ThrottledAPIBaseClient
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/plastered/utils/http_clients/red_client.py
+++ b/plastered/utils/http_clients/red_client.py
@@ -6,7 +6,7 @@ from plastered.models import RedUserDetails
 from plastered.models.red_models import ReleaseEntry
 from plastered.utils.constants import RED_API_BASE_URL, RED_JSON_RESPONSE_KEY
 from plastered.utils.exceptions import RedUserDetailsInitError
-from plastered.utils.httpx_utils.base_client import ThrottledAPIBaseClient
+from plastered.utils.http_clients.base_client import ThrottledAPIBaseClient
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/plastered/utils/http_clients/red_snatch_client.py
+++ b/plastered/utils/http_clients/red_snatch_client.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
-import httpx
+import httpx2
 
 from plastered.config.app_settings import AppSettings
 from plastered.utils.constants import RED_API_BASE_URL
 from plastered.utils.exceptions import RedClientSnatchException
-from plastered.utils.httpx_utils.base_client import ThrottledAPIBaseClient
+from plastered.utils.http_clients.base_client import ThrottledAPIBaseClient
 
 if TYPE_CHECKING:
     from plastered.models import RedUserDetails
@@ -28,7 +28,7 @@ class RedSnatchAPIClient(ThrottledAPIBaseClient):
             seconds_between_api_calls=app_settings.red.red_api_seconds_between_calls,
             # This class overrides the internal default super class routing, to make sure
             # there are no built-in request retries for snatching to prevent masking errors when using FL tokens.
-            extra_client_transport_mount_entries={RED_API_BASE_URL: httpx.HTTPTransport()},
+            extra_client_transport_mount_entries={RED_API_BASE_URL: httpx2.HTTPTransport()},
         )
         self._client.headers.update({"Authorization": app_settings.red.red_api_key.get_secret_value()})
         self._red_user_details: RedUserDetails | None = None

--- a/plastered/utils/httpx_utils/__init__.py
+++ b/plastered/utils/httpx_utils/__init__.py
@@ -1,6 +1,0 @@
-from plastered.utils.httpx_utils.lfm_client import LFMAPIClient
-from plastered.utils.httpx_utils.musicbrainz_client import MusicBrainzAPIClient
-from plastered.utils.httpx_utils.red_client import RedAPIClient
-from plastered.utils.httpx_utils.red_snatch_client import RedSnatchAPIClient
-
-__all__ = ["LFMAPIClient", "MusicBrainzAPIClient", "RedAPIClient", "RedSnatchAPIClient"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 	"beautifulsoup4==4.15.0",
 	"diskcache==5.6.3",
 	"fastapi[all]==0.140.0",
-	"httpx==0.28.1",
+	"httpx2>=2.9.0",
 	"jinja2-fragments==1.12.0",
 	"jsonschema==4.26.0",
 	"pydantic==2.13.4",
@@ -36,7 +36,7 @@ test = [
 	"jsonschema-markdown==2025.10.1",
 	"pytest==9.1.1",
 	"pytest-cov[toml]==7.1.0",
-	"pytest-httpx==0.36.2",
+	"pytest-httpx2>=1.0.0",
 	"pytest-mock>=3.15.1",
 	"pytest-socket>=0.8.0",
 	"pytest-xdist==3.8.0",
@@ -205,7 +205,10 @@ markers = [
     "releasetest: mark test as a release-only test which should be skipped on non-release builds.",
     "slow: mark test as a slow test which should be skipped by default in non-CI builds unless `--slowtests` is provided.",
     "no_autouse_mock_lifespan_singleton_inst: mark a test to not use the auto-use fixture for the fastapi lifespan singleton.",
-    "override_global_httpx_mock: mark a test to override the configured httpx global fixture in favor of its own.",
+    "override_global_httpx_mock: mark a test to override the configured httpx2 global fixture in favor of its own.",
+    # pytest-httpx2 1.0.0 defines this marker but its entry point doesn't expose the plugin's pytest_configure,
+    # so register it here to avoid PytestUnknownMarkWarning.
+    "httpx2(assert_all_called=False, assert_all_mocked=True, base_url=None): configure the httpx2_mock fixture (see https://lundberg.github.io/respx/api/#configuration).",
     "anyio: mark an async test to be run via anyio's pytest plugin (see the `anyio_backend` fixture in tests/conftest.py).",
 ]
 filterwarnings = [

--- a/tests/api_tests/conftest.py
+++ b/tests/api_tests/conftest.py
@@ -10,7 +10,7 @@ from plastered.api.app import create_fastapi_app
 from plastered.config.app_settings import AppSettings
 from plastered.models.red_models import RedUserDetails
 from plastered.release_search.release_searcher import ReleaseSearcher
-from plastered.utils.httpx_utils.red_client import RedAPIClient
+from plastered.utils.http_clients.red_client import RedAPIClient
 from plastered.version import get_project_version
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,16 +8,14 @@ import os
 os.environ["PLASTERED_CONFIG"] = os.path.join(os.environ["APP_DIR"], "examples", "config.yaml")
 from sqlmodel import SQLModel, Session, StaticPool, create_engine
 
-import re
 from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
-import httpx
 import pytest
+import respx
 import yaml
-from pytest_httpx import HTTPXMock
 
 from plastered.config.app_settings import AppSettings, get_app_settings
 from plastered.db.db_models import FailReason, SearchRecord
@@ -94,9 +92,9 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_release)
         if "slow" in item.keywords and not include_slow_tests:
             item.add_marker(skip_slow)
-        # https://pypi.org/project/pytest-httpx/#for-the-whole-test-suite
+        # https://lundberg.github.io/respx/api/#configuration
         # TODO: see if this can be removed
-        item.add_marker(pytest.mark.httpx_mock(assert_all_responses_were_requested=False))
+        item.add_marker(pytest.mark.httpx2(assert_all_called=False))
 
 
 @pytest.fixture
@@ -537,38 +535,6 @@ def expected_red_format_list() -> list[RedFormat]:
     ]
 
 
-def mock_lfm_client_callback(request: httpx.Request) -> httpx.Response:
-    """
-    Callback function used by the global_httpx_mock fixture (defined below) for any
-    unit tests which run HTTP calls to the LFM api.
-    """
-    lfm_actions_to_mock_json = {
-        "album.getinfo": load_mock_response_json(json_filepath=_LFM_MOCK_ALBUM_INFO_JSON_FILEPATH),
-        "track.getinfo": load_mock_response_json(json_filepath=_LFM_MOCK_TRACK_INFO_JSON_FILEPATH),
-    }
-    m = re.match(r"^.*\?.*method=(album\.getinfo|track\.getinfo).*$", str(request.url))
-    lfm_action = m.groups()[0]
-    mock_json = lfm_actions_to_mock_json[lfm_action]
-    return httpx.Response(status_code=200, json=mock_json)
-
-
-def mock_musicbrainz_client_callback(request: httpx.Request) -> httpx.Response:
-    """
-    Callback function used by the global_httpx_mock fixture (defined below) for any
-    unit tests which run HTTP calls to the musicbrainz api.
-    """
-    mb_endpoints_to_mock_json = {
-        "release": load_mock_response_json(json_filepath=_MUSICBRAINZ_MOCK_RELEASE_JSON_FILEPATH),
-        "recording": load_mock_response_json(json_filepath=_MUSICBRAINZ_MOCK_RECORDING_TRACK_ARTIST_NAME_JSON_FILEPATH),
-    }
-    # "https://musicbrainz.org/ws/2/" + "(release|recording)/.*"
-    url_val = str(request.url)
-    m = re.match(r"^.*musicbrainz\.org/ws/2/(release|recording)/.*", url_val)
-    mb_endpoint = m.groups()[0]
-    mock_json = mb_endpoints_to_mock_json[mb_endpoint]
-    return httpx.Response(status_code=200, json=mock_json)
-
-
 @pytest.fixture(scope="session")
 def red_url_regex_to_mock_json(
     mock_red_browse_non_empty_response: dict[str, Any],
@@ -638,36 +604,30 @@ def mb_url_regex_to_mock_json(
 @pytest.fixture(scope="function", autouse=True)
 def global_httpx_mock(
     request: pytest.FixtureRequest,
-    httpx_mock: HTTPXMock,
+    httpx2_mock: respx.Router,
     red_url_regex_to_mock_json: list[tuple[str, dict[str, Any]]],
     lfm_url_regex_to_mock_json: list[tuple[str, dict[str, Any]]],
     mb_url_regex_to_mock_json: list[tuple[str, dict[str, Any]]],
-) -> Generator[HTTPXMock, Any, Any]:
+) -> Generator[respx.Router, Any, Any]:
     """
     Globally applied fixture to ensure no HTTP requests in the unit tests
-    leak out to the actual network. via pytest-httpx:  https://pypi.org/project/pytest-httpx/
+    leak out to the actual network. via pytest-httpx2:  https://pypi.org/project/pytest-httpx2/
     """
     # Do not add any expected responses to this fixture for the edge-case tests which need to run with their own
     # function-specific mock responses. https://stackoverflow.com/a/38763328
     if "override_global_httpx_mock" in request.keywords:
-        yield httpx_mock
+        yield httpx2_mock
     else:
         for red_regex_and_json in red_url_regex_to_mock_json:
             request_url_pattern, resp_mock_json = red_regex_and_json
-            httpx_mock.add_response(
-                url=re.compile(request_url_pattern), json=resp_mock_json, is_optional=True, is_reusable=True
-            )
+            httpx2_mock.route(url__regex=request_url_pattern).respond(json=resp_mock_json)
         for lfm_regex_and_json in lfm_url_regex_to_mock_json:
             request_url_pattern, resp_mock_json = lfm_regex_and_json
-            httpx_mock.add_response(
-                url=re.compile(request_url_pattern), json=resp_mock_json, is_optional=True, is_reusable=True
-            )
+            httpx2_mock.route(url__regex=request_url_pattern).respond(json=resp_mock_json)
         for mb_regex_and_json in mb_url_regex_to_mock_json:
             request_url_pattern, resp_mock_json = mb_regex_and_json
-            httpx_mock.add_response(
-                url=re.compile(request_url_pattern), json=resp_mock_json, is_optional=True, is_reusable=True
-            )
-        yield httpx_mock
+            httpx2_mock.route(url__regex=request_url_pattern).respond(json=resp_mock_json)
+        yield httpx2_mock
 
 
 @pytest.fixture(scope="session")

--- a/tests/release_search_tests/processors_tests/test_chains.py
+++ b/tests/release_search_tests/processors_tests/test_chains.py
@@ -8,7 +8,7 @@ from plastered.models import EntityType, SearchItem
 from plastered.release_search.search_helpers import SearchState
 from plastered.release_search.processors import SearchItemProcessorChain
 from plastered.release_search.processors.bases import SearchItemProcessor
-from plastered.utils.httpx_utils import LFMAPIClient, MusicBrainzAPIClient, RedAPIClient
+from plastered.utils.http_clients import LFMAPIClient, MusicBrainzAPIClient, RedAPIClient
 
 
 # Function-scoped: each test gets a fresh chain so no test can leak mutated state (e.g. a patched

--- a/tests/release_search_tests/processors_tests/test_modifiers.py
+++ b/tests/release_search_tests/processors_tests/test_modifiers.py
@@ -4,7 +4,6 @@ from typing import Any, TypedDict
 from unittest.mock import MagicMock, patch, PropertyMock
 
 import pytest
-from pytest_httpx import HTTPXMock
 
 from plastered.config.app_settings import AppSettings
 from plastered.db.db_models import SearchRecord, SkipReason
@@ -34,8 +33,8 @@ from plastered.release_search.processors.modifiers import (
 from plastered.release_search.processors.bases import SearchItemModifier
 from plastered.release_search.search_helpers import SearchState
 from plastered.utils.exceptions import LFMClientException, MusicBrainzClientException
-from plastered.utils.httpx_utils.base_client import ThrottledAPIBaseClient
-from plastered.utils.httpx_utils import LFMAPIClient, MusicBrainzAPIClient, RedAPIClient
+from plastered.utils.http_clients.base_client import ThrottledAPIBaseClient
+from plastered.utils.http_clients import LFMAPIClient, MusicBrainzAPIClient, RedAPIClient
 
 
 class _MockProcKwargs(TypedDict):

--- a/tests/release_search_tests/test_release_searcher.py
+++ b/tests/release_search_tests/test_release_searcher.py
@@ -18,7 +18,7 @@ from plastered.release_search.processors import SearchItemProcessorChain
 from plastered.release_search.release_searcher import ReleaseSearcher, _dedupe_recs
 from plastered.release_search.search_helpers import SearchState
 from plastered.snatch import Snatcher
-from plastered.utils.httpx_utils import LFMAPIClient, MusicBrainzAPIClient, RedAPIClient, RedSnatchAPIClient
+from plastered.utils.http_clients import LFMAPIClient, MusicBrainzAPIClient, RedAPIClient, RedSnatchAPIClient
 
 
 @pytest.fixture(scope="function")

--- a/tests/snatch_tests/test_snatcher.py
+++ b/tests/snatch_tests/test_snatcher.py
@@ -7,7 +7,7 @@ import pytest
 from plastered.models import EntityType as et, LFMRec, RecContext as rc, SearchItem, TorrentEntry as te
 from plastered.release_search.search_helpers import SearchState
 from plastered.snatch import Snatcher
-from plastered.utils.httpx_utils import RedSnatchAPIClient
+from plastered.utils.http_clients import RedSnatchAPIClient
 
 SnatcherFactory = Callable[..., tuple[Snatcher, MagicMock, MagicMock]]
 
@@ -48,7 +48,7 @@ def make_snatcher() -> Generator[SnatcherFactory, None, None]:
     context managers so their lifecycle is cleaned up automatically once the consuming test completes.
     """
     with (
-        patch("plastered.utils.httpx_utils.RedSnatchAPIClient", spec=RedSnatchAPIClient) as mock_red_snatch_client,
+        patch("plastered.utils.http_clients.RedSnatchAPIClient", spec=RedSnatchAPIClient) as mock_red_snatch_client,
         patch("plastered.release_search.search_helpers.SearchState", spec=SearchState) as mock_search_state,
     ):
 

--- a/tests/utils_tests/http_clients_tests/test_http_clients.py
+++ b/tests/utils_tests/http_clients_tests/test_http_clients.py
@@ -6,8 +6,8 @@ import pytest
 
 from plastered.config.app_settings import AppSettings
 from plastered.utils.constants import LFM_API_BASE_URL, MUSICBRAINZ_API_BASE_URL, RED_API_BASE_URL
-from plastered.utils.httpx_utils.base_client import ThrottledAPIBaseClient, precise_delay
-from plastered.utils.httpx_utils import LFMAPIClient, MusicBrainzAPIClient, RedAPIClient, RedSnatchAPIClient
+from plastered.utils.http_clients.base_client import ThrottledAPIBaseClient, precise_delay
+from plastered.utils.http_clients import LFMAPIClient, MusicBrainzAPIClient, RedAPIClient, RedSnatchAPIClient
 
 
 @pytest.mark.slow
@@ -88,9 +88,9 @@ def test_throttle(client_throttle_sec: int, raw_now_timestamps: list[int], expec
     expected_num_throttle_calls = len(dt_now_call_timestamps) // 2
     expected_datetime_now_call_cnt = len(dt_now_call_timestamps)
     # NOTE: mocking datetime is funky. Had to follow this advice: https://stackoverflow.com/a/70598060
-    with patch("plastered.utils.httpx_utils.base_client.datetime", wraps=datetime.datetime) as mock_dt:
+    with patch("plastered.utils.http_clients.base_client.datetime", wraps=datetime.datetime) as mock_dt:
         mock_dt.now.side_effect = dt_now_call_timestamps
-        with patch("plastered.utils.httpx_utils.base_client.precise_delay") as mock_precise_delay:
+        with patch("plastered.utils.http_clients.base_client.precise_delay") as mock_precise_delay:
             mock_precise_delay.return_value = None
             assert api_base_client._throttle_period == datetime.timedelta(seconds=client_throttle_sec)
             for _ in range(expected_num_throttle_calls):
@@ -168,7 +168,7 @@ def test_throttle_serializes_concurrent_callers() -> None:
         with events_lock:
             events.append(("exit", perf_counter()))
 
-    with patch("plastered.utils.httpx_utils.base_client.precise_delay", side_effect=_recording_precise_delay):
+    with patch("plastered.utils.http_clients.base_client.precise_delay", side_effect=_recording_precise_delay):
         threads = [threading.Thread(target=client._throttle) for _ in range(2)]
         for thread in threads:
             thread.start()

--- a/tests/utils_tests/http_clients_tests/test_lfm_client.py
+++ b/tests/utils_tests/http_clients_tests/test_lfm_client.py
@@ -2,12 +2,12 @@ from contextlib import nullcontext
 from unittest.mock import Mock, patch
 
 import pytest
-from pytest_httpx import HTTPXMock
+import respx
 
 from plastered.config.app_settings import AppSettings
 from plastered.models.search_item import SearchItem
 from plastered.utils.exceptions import LFMClientException
-from plastered.utils.httpx_utils import LFMAPIClient
+from plastered.utils.http_clients import LFMAPIClient
 
 
 @pytest.fixture(scope="session")
@@ -41,8 +41,10 @@ def test_request_lfm_api(
 
 @pytest.mark.override_global_httpx_mock
 @pytest.mark.parametrize("method", ["album.getinfo", "track.getinfo"])
-def test_request_lfm_api_non_200_status(httpx_mock: HTTPXMock, valid_app_settings: AppSettings, method: str) -> None:
-    httpx_mock.add_response(status_code=404)
+def test_request_lfm_api_non_200_status(
+    httpx2_mock: respx.Router, valid_app_settings: AppSettings, method: str
+) -> None:
+    httpx2_mock.route().respond(status_code=404)
     lfm_client = LFMAPIClient(app_settings=valid_app_settings)
     lfm_client._throttle = Mock(name="_throttle")
     lfm_client._throttle.return_value = None
@@ -53,8 +55,10 @@ def test_request_lfm_api_non_200_status(httpx_mock: HTTPXMock, valid_app_setting
 
 @pytest.mark.override_global_httpx_mock
 @pytest.mark.parametrize("method", ["album.getinfo", "track.getinfo"])
-def test_request_lfm_api_bad_json_response(httpx_mock: HTTPXMock, valid_app_settings: AppSettings, method: str) -> None:
-    httpx_mock.add_response(
+def test_request_lfm_api_bad_json_response(
+    httpx2_mock: respx.Router, valid_app_settings: AppSettings, method: str
+) -> None:
+    httpx2_mock.route().respond(
         status_code=200, json={"error": 123, "message": "LFM API handles errors like this sometimes"}
     )
     lfm_client = LFMAPIClient(app_settings=valid_app_settings)

--- a/tests/utils_tests/http_clients_tests/test_mb_client.py
+++ b/tests/utils_tests/http_clients_tests/test_mb_client.py
@@ -3,11 +3,11 @@ from typing import Any
 from unittest.mock import Mock
 
 import pytest
-from pytest_httpx import HTTPXMock
+import respx
 
 from plastered.config.app_settings import AppSettings
 from plastered.utils.exceptions import MusicBrainzClientException
-from plastered.utils.httpx_utils.musicbrainz_client import MusicBrainzAPIClient
+from plastered.utils.http_clients.musicbrainz_client import MusicBrainzAPIClient
 
 
 @pytest.fixture(scope="session")
@@ -109,7 +109,7 @@ def test_mb_get_track_search_query_str(
     ],
 )
 def test_request_release_details_for_track(
-    httpx_mock: HTTPXMock,
+    httpx2_mock: respx.Router,
     request: pytest.FixtureRequest,
     valid_app_settings: AppSettings,
     make_track_search_item: pytest.FixtureRequest,
@@ -121,7 +121,7 @@ def test_request_release_details_for_track(
     expected: dict[str, str | None] | None,
 ) -> None:
     mock_json_resp = request.getfixturevalue(mock_mb_json_response_fixture_name)
-    httpx_mock.add_response(json=mock_json_resp)
+    httpx2_mock.route().respond(json=mock_json_resp)
     mb_client = MusicBrainzAPIClient(app_settings=valid_app_settings)
     mb_client._throttle = Mock(name="_throttle")
     mb_client._throttle.return_value = None
@@ -131,8 +131,8 @@ def test_request_release_details_for_track(
 
 
 @pytest.mark.override_global_httpx_mock
-def test_request_release_details_error_handling(httpx_mock: HTTPXMock, valid_app_settings: AppSettings) -> None:
-    httpx_mock.add_response(status_code=404)
+def test_request_release_details_error_handling(httpx2_mock: respx.Router, valid_app_settings: AppSettings) -> None:
+    httpx2_mock.route().respond(status_code=404)
     mb_client = MusicBrainzAPIClient(app_settings=valid_app_settings)
     mb_client._throttle = Mock(name="_throttle")
     mb_client._throttle.return_value = None
@@ -145,12 +145,12 @@ def test_request_release_details_error_handling(httpx_mock: HTTPXMock, valid_app
 @pytest.mark.override_global_httpx_mock
 @pytest.mark.parametrize("is_lfm_rec", [False, True])
 def test_request_release_details_for_track_error_handling(
-    httpx_mock: HTTPXMock,
+    httpx2_mock: respx.Router,
     valid_app_settings: AppSettings,
     make_track_search_item: pytest.FixtureRequest,
     is_lfm_rec: bool,
 ) -> None:
-    httpx_mock.add_response(status_code=404)
+    httpx2_mock.route().respond(status_code=404)
     mb_client = MusicBrainzAPIClient(app_settings=valid_app_settings)
     mb_client._throttle = Mock(name="_throttle")
     mb_client._throttle.return_value = None

--- a/tests/utils_tests/http_clients_tests/test_red_client.py
+++ b/tests/utils_tests/http_clients_tests/test_red_client.py
@@ -4,16 +4,14 @@ from typing import Any
 from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 import pytest
-from pytest_httpx import HTTPXMock
 
 from plastered.config.app_settings import AppSettings
 from plastered.models.red_models import RedUserDetails, ReleaseEntry
 from plastered.models.types import RedReleaseType
 from plastered.utils.exceptions import RedUserDetailsInitError
-from plastered.utils.httpx_utils.red_client import RedAPIClient
+from plastered.utils.http_clients.red_client import RedAPIClient
 
 
-@pytest.mark.httpx_mock(assert_all_requests_were_expected=False)
 @pytest.mark.parametrize(
     "action, expected_top_keys",
     [

--- a/tests/utils_tests/http_clients_tests/test_red_snatch_client.py
+++ b/tests/utils_tests/http_clients_tests/test_red_snatch_client.py
@@ -3,18 +3,20 @@ from contextlib import nullcontext
 from unittest.mock import Mock
 
 import pytest
-from pytest_httpx import HTTPXMock
+import respx
 
 from plastered.config.app_settings import AppSettings
 from plastered.models.red_models import RedUserDetails
 from plastered.utils.exceptions import RedClientSnatchException
-from plastered.utils.httpx_utils.red_snatch_client import RedSnatchAPIClient
+from plastered.utils.http_clients.red_snatch_client import RedSnatchAPIClient
 
 
 @pytest.mark.override_global_httpx_mock
 @pytest.mark.parametrize("mock_response_code", [200, 404])
-def test_snatch_red_api_no_fl(httpx_mock: HTTPXMock, valid_app_settings: AppSettings, mock_response_code: int) -> None:
-    httpx_mock.add_response(status_code=mock_response_code)
+def test_snatch_red_api_no_fl(
+    httpx2_mock: respx.Router, valid_app_settings: AppSettings, mock_response_code: int
+) -> None:
+    httpx2_mock.route().respond(status_code=mock_response_code)
     red_snatch_client = RedSnatchAPIClient(app_settings=valid_app_settings)
     red_snatch_client._throttle = Mock(name="_throttle")
     red_snatch_client._throttle.return_value = None
@@ -35,7 +37,7 @@ def test_snatch_red_api_no_fl(httpx_mock: HTTPXMock, valid_app_settings: AppSett
     ids=["200_first_try", "200_second_try", "404_all", "500_404"],
 )
 def test_snatch_red_api_use_token(
-    httpx_mock: HTTPXMock,
+    httpx2_mock: respx.Router,
     valid_app_settings: AppSettings,
     mock_red_user_details: RedUserDetails,
     mock_response_codes: list[int],
@@ -43,8 +45,7 @@ def test_snatch_red_api_use_token(
     raise_client_exc: bool,
 ) -> None:
     expected_get_urls = [f"https://redacted.sh/ajax.php?action=download&{params}" for params in expected_get_params]
-    for mock_response_code in mock_response_codes:
-        httpx_mock.add_response(status_code=mock_response_code)
+    httpx2_mock.route().mock(side_effect=[respx.MockResponse(code) for code in mock_response_codes])
     expected_throttle_calls = len(expected_get_urls)
     red_snatch_client = RedSnatchAPIClient(app_settings=valid_app_settings)
     red_snatch_client._red_user_details = mock_red_user_details
@@ -53,7 +54,7 @@ def test_snatch_red_api_use_token(
     red_snatch_client._throttle.return_value = None
     with pytest.raises(RedClientSnatchException) if raise_client_exc else nullcontext():
         result = red_snatch_client.snatch(tid="69", can_use_token=True)
-    actual_requests = httpx_mock.get_requests()
+    actual_requests = [mock_call.request for mock_call in httpx2_mock.calls]
     assert len(actual_requests) == len(expected_get_urls)
     for i, expected_get_url in enumerate(expected_get_urls):
         assert str(actual_requests[i].url) == expected_get_url

--- a/uv.lock
+++ b/uv.lock
@@ -456,6 +456,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
@@ -493,12 +506,28 @@ wheels = [
 ]
 
 [[package]]
-name = "idna"
-version = "3.10"
+name = "httpx2"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -887,7 +916,7 @@ dependencies = [
     { name = "click" },
     { name = "diskcache" },
     { name = "fastapi", extra = ["all"] },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "jinja2-fragments" },
     { name = "jsonschema" },
     { name = "pydantic" },
@@ -914,7 +943,7 @@ test = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pytest-httpx" },
+    { name = "pytest-httpx2" },
     { name = "pytest-mock" },
     { name = "pytest-socket" },
     { name = "pytest-xdist" },
@@ -929,7 +958,7 @@ requires-dist = [
     { name = "click", specifier = "==8.4.2" },
     { name = "diskcache", specifier = "==5.6.3" },
     { name = "fastapi", extras = ["all"], specifier = "==0.140.0" },
-    { name = "httpx", specifier = "==0.28.1" },
+    { name = "httpx2", specifier = ">=2.9.0" },
     { name = "jinja2-fragments", specifier = "==1.12.0" },
     { name = "jsonschema", specifier = "==4.26.0" },
     { name = "pydantic", specifier = "==2.13.4" },
@@ -956,7 +985,7 @@ test = [
     { name = "mypy", specifier = "==1.19.1" },
     { name = "pytest", specifier = "==9.1.1" },
     { name = "pytest-cov", extras = ["toml"], specifier = "==7.1.0" },
-    { name = "pytest-httpx", specifier = "==0.36.2" },
+    { name = "pytest-httpx2", specifier = ">=1.0.0" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "pytest-socket", specifier = ">=0.8.0" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
@@ -1177,16 +1206,15 @@ wheels = [
 ]
 
 [[package]]
-name = "pytest-httpx"
-version = "0.36.2"
+name = "pytest-httpx2"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
-    { name = "pytest" },
+    { name = "respx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/42/f53c58570e80d503ade9dd42ce57f2915d14bcbe25f6308138143950d1d6/pytest_httpx-0.36.2.tar.gz", hash = "sha256:05a56527484f7f4e8c856419ea379b8dc359c36801c4992fdb330f294c690356", size = 57683, upload-time = "2026-04-09T13:57:19.837Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/d1/70e7edb50679ddd34ba5e13ac1d6e1223bc4e24d0a5fc30587f8fbe884c4/pytest_httpx2-1.0.0.tar.gz", hash = "sha256:d897a14c1341d3f3014e9432c16fed366598aba06a2ba9c08460a51799cb7128", size = 2882, upload-time = "2026-05-20T08:26:41.442Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/55/1fa65f8e4fceb19dd6daa867c162ad845d547f6058cd92b4b02384a44777/pytest_httpx-0.36.2-py3-none-any.whl", hash = "sha256:d42ebd5679442dc7bfb0c48e0767b6562e9bc4534d805127b0084171886a5e22", size = 20315, upload-time = "2026-04-09T13:57:18.587Z" },
+    { url = "https://files.pythonhosted.org/packages/54/e1/5e38e8de42fba9667846a43113469c7481d01db4b6511e42645385bace8f/pytest_httpx2-1.0.0-py3-none-any.whl", hash = "sha256:467dc7f6946854ffc20e1678703266b093037d8f3fb9f1fb523a2c432c64cff0", size = 4504, upload-time = "2026-05-20T08:26:40.219Z" },
 ]
 
 [[package]]
@@ -1321,6 +1349,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744, upload-time = "2025-01-25T08:48:16.138Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/b1/3baf80dc6d2b7bc27a95a67752d0208e410351e3feb4eb78de5f77454d8d/referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0", size = 26775, upload-time = "2025-01-25T08:48:14.241Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
 ]
 
 [[package]]
@@ -1608,6 +1648,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What?
* Migrates the underlying API clients for MB, LFM, and RED from `httpx` to `httpx2`, as the former appears to no longer be actively maintained.

## Why?
* Closes #121 

## Pre-merge Checklist
- [x] validated that local builds and tests passed with `make docker-test`
- [x] ensured that the changes do not violate any relevant API rate limits
- [x] any relevant documentation is updated to reflect the given changes
