### PR TITLE
fix: Add docker image details in release note generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,15 @@ jobs:
           VERSION_TAG: ${{ steps.bump.outputs.version }}
         run: |
           cog changelog --at "${VERSION_TAG}" > GITHUB_CHANGELOG.md
+          cat >> GITHUB_CHANGELOG.md <<EOF
+
+          ### Container Image
+          * Pull the latest release from GHCR:
+              \`\`\`shell
+              docker pull ghcr.io/${GITHUB_REPOSITORY}:${VERSION_TAG#v}
+              \`\`\`
+          * View package details on the [plastered packages page](https://github.com/${GITHUB_REPOSITORY}/pkgs/container/plastered)
+          EOF
           gh release create "${VERSION_TAG}" \
             --title "${VERSION_TAG#v}" \
             --notes-file GITHUB_CHANGELOG.md \


### PR DESCRIPTION
## What?
* Updates the `cocogitto` release action's job so that it appends links and commands for the release's corresponding Docker image.

## Why?
* All the relevant information for a release should be located in the release notes, including the new docker pull command and a link to the package itself.

## Pre-merge Checklist
- [x] validated that local builds and tests passed with `make docker-test`
- [x] ensured that the changes do not violate any relevant API rate limits
- [x] any relevant documentation is updated to reflect the given changes
