### PR TITLE
docs: Add API reference info to user docs

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -64,3 +64,7 @@ Everything is driven from the web UI:
 - **Config** — inspect the effective app config the server loaded.
 
 Snatched `.torrent` files are written to the mounted downloads directory; point your download client at it.
+
+## 5. Full REST API Reference
+
+You can view the full API documentation for your server at `<plastered URL and port here>/docs`.


### PR DESCRIPTION
## What?
* Adds details on where to find the full API reference in the user docs 

## Why?
* Best to surface just the swagger endpoint to avoid docs going out of date or needing to be versioned.

## Pre-merge Checklist
- [x] validated that local builds and tests passed with `make docker-test`
- [x] ensured that the changes do not violate any relevant API rate limits
- [x] any relevant documentation is updated to reflect the given changes
