### PR TITLE
feat: Default runtime user to non-root, allow configurable `uid` and `gid`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@
 !tests
 !pyproject.toml
 !uv.lock
+!docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,10 @@ LABEL org.opencontainers.image.source="https://github.com/windexvalence/plastere
 LABEL org.opencontainers.image.version="${PLASTERED_RELEASE_TAG#v}"
 
 WORKDIR /app
-ENV PYTHONDONTWRITEBYTECODE=1
+# PLAYWRIGHT_BROWSERS_PATH: install the browser into a world-readable shared path instead of the
+# default ~/.cache/ms-playwright — /root is 0700, so a root-home install would be unreadable to the
+# non-root runtime user. Set before the install RUN below and kept for runtime resolution.
+ENV PYTHONDONTWRITEBYTECODE=1 PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
 # The single PEX is the entire application: 1st-party sources (incl. static/templates/pyproject.toml,
 # all resolved at runtime via importlib.resources) + all locked 3rd-party deps.
 COPY --from=pex-builder /plastered.pex /app/plastered.pex
@@ -61,12 +64,24 @@ RUN PEX_ROOT=/tmp/pex-root PEX_SCRIPT=rebrowser_playwright /app/plastered.pex in
     && rm -rf /tmp/pex-root \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /root/.cache/ms-playwright/ffmpeg-* \
+    && rm -rf ${PLAYWRIGHT_BROWSERS_PATH}/ffmpeg-* \
     && rm -rf /usr/share/doc /usr/share/man
-ENV APP_DIR=/app FORCE_COLOR=1 PLASTERED_RELEASE_TAG=${PLASTERED_RELEASE_TAG}
-# `run` resolves the config path from the PLASTERED_CONFIG env var and launches uvicorn with the
-# host / port / log level / workers from the app config.
-ENTRYPOINT ["/app/plastered.pex", "run"]
+# The non-root runtime user. PUID/PGID are its default ids and double as the remap request read by
+# docker-entrypoint.sh: launching with `--user root -e PUID=<uid> -e PGID=<gid>` remaps the
+# `plastered` user linuxserver.io-style and re-drops privileges before booting the app. PEX_ROOT
+# (where the PEX extracts its venv on first boot) is /tmp-style world-writable so arbitrary
+# `docker run --user <uid>:<gid>` launches work too.
+ENV PUID=1000 PGID=1000
+RUN groupadd --gid "${PGID}" plastered \
+    && useradd --uid "${PUID}" --gid plastered --create-home --shell /usr/sbin/nologin plastered \
+    && mkdir --parents --mode=1777 /app/.pex
+COPY --chmod=755 ./docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+ENV APP_DIR=/app FORCE_COLOR=1 PLASTERED_RELEASE_TAG=${PLASTERED_RELEASE_TAG} PEX_ROOT=/app/.pex
+USER plastered
+# The entrypoint execs `/app/plastered.pex run`; `run` resolves the config path from the
+# PLASTERED_CONFIG env var and launches uvicorn with the host / port / log level / workers from
+# the app config.
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 
 ########## Stage 3: the test image (CI + local dev only; size does not matter here) ##########
 FROM python:3.14.7-slim-bookworm AS plastered-test

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ docker-server:  docker-build-no-test  ## Execs a local container running the ser
 		-v $(DOWNLOADS_DIR):/downloads \
 		-e PLASTERED_CONFIG=/config/config.yaml \
 		-e DB_TEST_MODE=$(DB_TEST_MODE) \
+		--user root -e PUID=$$(id -u) -e PGID=$$(id -g) \
 		wv/plastered:non-test
 
 docker-py-shell:  docker-build  ## Execs a local python shell inside a locally built plastered docker container for testing and debugging

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Runtime entrypoint for the app image (Dockerfile stage `plastered-app`).
+#
+# The image defaults to the non-root `plastered` user via the Dockerfile's USER instruction (ids
+# from its PUID/PGID ENV defaults), so normally this script just boots the server. Remapping to
+# other ids linuxserver.io-style needs root: launch with `--user root -e PUID=<uid> -e PGID=<gid>`
+# and this script remaps the `plastered` user to those ids, hands the app's writable paths to it,
+# and re-drops privileges before booting the server — the app process itself never runs as root.
+set -eu
+
+if [ "$(id -u)" -ne 0 ]; then
+    exec /app/plastered.pex run "$@"
+fi
+
+echo "[docker-entrypoint] remapping the runtime user to uid:gid ${PUID}:${PGID} and dropping root privileges"
+
+if [ "$(id -g plastered)" -ne "${PGID}" ]; then
+    groupmod --non-unique --gid "${PGID}" plastered
+fi
+if [ "$(id -u plastered)" -ne "${PUID}" ] || [ "$(id -g plastered)" -ne "${PGID}" ]; then
+    usermod --non-unique --uid "${PUID}" --gid "${PGID}" plastered
+fi
+
+# The app's writable image paths: PEX_ROOT (the venv the PEX extracts into on first boot) and the
+# user's home (browser profile/crash dirs).
+chown -R plastered:plastered "${PEX_ROOT}" /home/plastered
+
+# The config dir must be writable too (the SQLite DB lives next to config.yaml). It is usually a
+# host volume, so chown it to the requested ids like linuxserver images do for /config — but never
+# touch '/' and only warn on failure. The downloads dir is deliberately left alone: ensure the
+# host directory is writable by PUID:PGID.
+if [ -n "${PLASTERED_CONFIG:-}" ]; then
+    config_dir="$(dirname -- "${PLASTERED_CONFIG}")"
+    if [ "${config_dir}" != "/" ] && [ -d "${config_dir}" ]; then
+        chown -R plastered:plastered "${config_dir}" \
+            || echo "[docker-entrypoint] WARNING: could not chown ${config_dir}; ensure it is writable by ${PUID}:${PGID}" >&2
+    fi
+fi
+
+export HOME=/home/plastered
+exec setpriv --reuid plastered --regid plastered --init-groups /app/plastered.pex run "$@"

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -52,6 +52,32 @@ Then open <http://localhost:8000/> in your browser.
 > The container serves the app on port 80 internally; the `-p 8000:80` above exposes it as `localhost:8000` on your
 > host — change the left-hand `8000` if that port is taken.
 
+### User / Group Identifiers
+
+The app never runs as root: the image defaults to a non-root user with uid:gid `1000:1000`. When using volumes (`-v`
+flags), permissions issues can arise between the host OS and the container — avoid them by matching the container's
+ids to the host user that owns your mounted directories. To find that user's ids, run `id your_user`:
+
+```shell
+$ id your_user
+uid=1000(your_user) gid=1000(your_user) groups=1000(your_user)
+```
+
+If those ids are not `1000:1000`, pick one of these ways to change the container's ids:
+
+- **`PUID`/`PGID` environment variables (linuxserver.io-style):** start the container as root so it can remap its
+  internal user; it re-drops privileges to the requested ids before booting the app:
+
+  ```shell
+  docker run ... --user root -e PUID=1000 -e PGID=1000 ...
+  ```
+
+  On startup the config directory is chowned to those ids automatically (it holds the app's SQLite DB); the
+  downloads directory is left untouched, so ensure it is writable by `PUID:PGID`.
+
+- **`--user` (docker-native):** `docker run --user <uid>:<gid>` runs the app directly as those ids. Nothing is
+  chowned for you, so both mounted directories must already be writable by those ids.
+
 ## 4: Use the App
 
 Everything is driven from the web UI:


### PR DESCRIPTION
## What?
* Ensures the default container runtime user is non-root
* Allows users to specify the container runtime user and usergroup via the `PUID` and `PGID` environment variables (similar to how [`linuxserver.io`](https://docs.linuxserver.io/images/) does.

## Why?
* Closes #83 
* Better configurability for end users, slightly better security practice

## Pre-merge Checklist
- [x] validated that local builds and tests passed with `make docker-test`
- [x] ensured that the changes do not violate any relevant API rate limits
- [x] any relevant documentation is updated to reflect the given changes
